### PR TITLE
Add the ability to set a From: address on emails

### DIFF
--- a/cron_cmd.go
+++ b/cron_cmd.go
@@ -102,7 +102,7 @@ func (p *cronCmd) ProcessURL(input string) error {
 				text := html2text.HTML2Text(content)
 
 				// Send the mail
-				err := SendMail(input, p.emails, i.Title, i.Link, text, content)
+				err := SendMail(input, p.fromAddr, p.emails, i.Title, i.Link, text, content)
 				if err != nil {
 					return err
 				}
@@ -124,6 +124,10 @@ type cronCmd struct {
 
 	// Should we send emails?
 	send bool
+
+	// The address all emails should be sent from.  If omitted,
+	// the From: address is the same as the To: address.
+	fromAddr string
 }
 
 //
@@ -143,6 +147,7 @@ func (*cronCmd) Usage() string {
 func (p *cronCmd) SetFlags(f *flag.FlagSet) {
 	f.BoolVar(&p.verbose, "verbose", false, "Should we be extra verbose?")
 	f.BoolVar(&p.send, "send", true, "Should we send emails, or just pretend to?")
+	f.StringVar(&p.fromAddr, "from", "", "Specify an email address the email will be sent from.")
 }
 
 //

--- a/email_send.go
+++ b/email_send.go
@@ -79,7 +79,7 @@ func toQuotedPrintable(s string) (string, error) {
 //
 // We send a MIME message with both a plain-text and a HTML-version of the
 // message.  This should be nicer for users.
-func SendMail(feedURL string, addresses []string, subject string, link string, textstr string, htmlstr string) error {
+func SendMail(feedURL string, fromAddr string, addresses []string, subject string, link string, textstr string, htmlstr string) error {
 	var err error
 
 	//
@@ -117,6 +117,9 @@ func SendMail(feedURL string, addresses []string, subject string, link string, t
 		x.To = addr
 		x.Feed = feedURL
 		x.From = addr
+		if fromAddr != "" {
+			x.From = fromAddr
+		}
 		x.Text, err = toQuotedPrintable(textstr)
 		if err != nil {
 			return err


### PR DESCRIPTION
Add a -from="email_address" flag to specify an email address that
emails are sent from.  If not specified, the From: address in each
email will still be the same as the To: address.
