### PR TITLE
Allow templated subject: & from: field-construction.

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,13 @@ When new items appear in the feeds they will then be sent to you via email.
 Each email will be multi-part, containing both `text/plain` and `text/html`
 versions of the new post(s).
 
+If you run `rss2email help cron` you'll see that it is possible to customize
+the senders' email address, as well as a format-string used to construct the
+email `Subject:` header.  By default generated emails will use the following
+template-string, which matches that produced by the original `rss2email` project:
+
+* `[rss2email] #{ITEM.TITLE}`
+
 
 ## Initial Run
 

--- a/README.md
+++ b/README.md
@@ -23,8 +23,7 @@ This project is a naive port of the [r2e](https://github.com/wking/rss2email) pr
 
 ## Rationale
 
-I prefer to keep my server(s) pretty minimal, and replacing `r2e` allowed
-me to remove a bunch of Python packages I otherwise have no need for:
+I prefer to keep my server(s) pretty minimal, and replacing `r2e` allowed me to remove a bunch of Python packages I otherwise had no need for:
 
       steve@ssh ~ $ sudo dpkg --purge rss2email
       Removing rss2email (1:3.9-2.1) ...
@@ -38,7 +37,7 @@ me to remove a bunch of Python packages I otherwise have no need for:
        python3-html5lib python3-lxml python3-six python3-webencodings
       0 upgraded, 0 newly installed, 9 to remove and 0 not upgraded.
 
-This project, being built in go, is self-contained and easy to deploy without the need for additional external libraries.
+This project, being built in [golang](https://golang.org), is self-contained and easy to deploy without the need for additional external libraries.
 
 
 
@@ -62,8 +61,7 @@ If you prefer you can fetch a binary from [our release page](https://github.com/
 
 # Configuration
 
-Once you have a binary you'll need to configure the feeds to monitor. To
-add a new feed use the `add` sub-command:
+Once you have a binary you'll need to configure the feeds to monitor. To add a new feed use the `add` sub-command:
 
      $ rss2email add https://example.com/blog.rss
      $ rss2email add https://example.net/index.rss
@@ -79,35 +77,28 @@ Or delete a feed by specifying the item to remove:
 
 > **NOTE**: Feeds are stored in `~/.rss2email/feeds`, you might prefer to edit that directly.  Just add one URI per line.
 
-Once you've added your feeds you should then add the binary to your
-`crontab`, to ensure it runs regularly to actually send you the emails.
-You should add something similar to this to your `crontab`:
+Once you've added your feeds you should then add the binary to your `crontab`, to ensure it runs regularly to actually send you the emails. You should add something similar to this to your `crontab`:
 
-     # Announce feed-changes via email
+     # Announce feed-changes via email every fifteen minutes
      */15 * * * * $HOME/go/bin/rss2email cron user@example.com
 
 When new items appear in the feeds they will then be sent to you via email.
-Each email will be multi-part, containing both `text/plain` and `text/html`
-versions of the new post(s).
 
-If you run `rss2email help cron` you'll see that it is possible to customize
-the senders' email address, as well as a format-string used to construct the
-email `Subject:` header.  By default generated emails will use the following
-template-string, which matches that produced by the original `rss2email` project:
+Each email will be multi-part, containing both `text/plain` and `text/html` versions of the new post(s).
+
+If you run `rss2email help cron` you'll see that it is possible to customize the senders' email address, as well as a format-string used to construct the email `Subject:` header.  By default generated emails will use the following template-string, which matches that produced by the original `r2e` project:
 
 * `[rss2email] #{ITEM.TITLE}`
 
 
 ## Initial Run
 
-When you add a new feed all the items will initially be unseen/new, and
-this means you'll receive a flood of emails if you were to run:
+When you add a new feed all the items will initially be unseen/new, and this means you'll receive a flood of emails if you were to run:
 
      $ rss2email add https://blog.steve.fi/index.rss
      $ rss2email cron
 
-To avoid this you can use the `-send=false` flag, which will merely
-record each item as having been seen, rather than sending you emails:
+To avoid this you can use the `-send=false` flag, which will merely record each item as having been seen, rather than sending you emails:
 
      $ rss2email add https://blog.steve.fi/index.rss
      $ rss2email cron -send=false
@@ -115,22 +106,20 @@ record each item as having been seen, rather than sending you emails:
 
 # Assumptions
 
-Because this application is so minimal there are a number of assumptions baked in:
+There are a number of assumptions baked into this application:
 
 * We assume that `/usr/sbin/sendmail` exists and will send email successfully.
 * We assume the recipient and sender email addresses can be the same.
   * i.e. If you mail output to `bob@example.com` that will be used as the sender address.
+  * But you can change that if you wish, via `-from`
 
 
 # Github Setup
 
-This repository is configured to run tests upon every commit, and when
-pull-requests are created/updated.  The testing is carried out via
-[.github/run-tests.sh](.github/run-tests.sh) which is used by the
-[github-action-tester](https://github.com/skx/github-action-tester) action.
+This repository is configured to run tests upon every commit, and when pull-requests are created/updated.  The testing is carried out via [.github/run-tests.sh](.github/run-tests.sh) which is used by the [github-action-tester](https://github.com/skx/github-action-tester) action.
 
-Releases are automated in a similar fashion via [.github/build](.github/build),
-and the [github-action-publish-binaries](https://github.com/skx/github-action-publish-binaries) action.
+Releases are automated in a similar fashion via [.github/build](.github/build), and the [github-action-publish-binaries](https://github.com/skx/github-action-publish-binaries) action.
+
 
 Steve
 --

--- a/cron_cmd.go
+++ b/cron_cmd.go
@@ -107,6 +107,11 @@ func (p *cronCmd) ProcessURL(input string) error {
 			subject = strings.ReplaceAll(subject, "#{ITEM.AUTHOR.NAME}", aName)
 			subject = strings.ReplaceAll(subject, "#{ITEM.AUTHOR.EMAIL}", aMail)
 
+			// Show the expansion.
+			if p.verbose {
+				fmt.Printf("\tExpanded Subject-template '%s' -> '%s'\n", p.subject, subject)
+			}
+
 			// If we're supposed to send email then do that
 			if p.send {
 

--- a/cron_cmd.go
+++ b/cron_cmd.go
@@ -96,8 +96,16 @@ func (p *cronCmd) ProcessURL(input string) error {
 			subject = strings.ReplaceAll(subject, "#{ITEM.LINK}", i.Link)
 
 			// Author
-			subject = strings.ReplaceAll(subject, "#{ITEM.AUTHOR.NAME}", i.Author.Name)
-			subject = strings.ReplaceAll(subject, "#{ITEM.AUTHOR.EMAIL}", i.Author.Email)
+			aMail := ""
+			aName := ""
+			if i.Author != nil && i.Author.Name != "" {
+				aName = i.Author.Name
+			}
+			if i.Author != nil && i.Author.Email != "" {
+				aMail = i.Author.Email
+			}
+			subject = strings.ReplaceAll(subject, "#{ITEM.AUTHOR.NAME}", aName)
+			subject = strings.ReplaceAll(subject, "#{ITEM.AUTHOR.EMAIL}", aMail)
 
 			// If we're supposed to send email then do that
 			if p.send {

--- a/email_send.go
+++ b/email_send.go
@@ -23,7 +23,7 @@ import (
 var Template = `Content-Type: multipart/mixed; boundary=21ee3da964c7bf70def62adb9ee1a061747003c026e363e47231258c48f1
 From: {{.From}}
 To: {{.To}}
-Subject: [rss2email] {{.Subject}}
+Subject: {{.Subject}}
 X-RSS-Link: {{.Link}}
 X-RSS-Feed: {{.Feed}}
 Mime-Version: 1.0


### PR DESCRIPTION
This pull-request allows the user to customize the generated email `Subject:` header, via a simple series of template-expansions.

These are documented in the output of `rss2email help cron`:

```
$ ./rss2email help cron
cron :
Read the list of feeds and send email for each new item found in them.

By default emails are sent to the address specified upon the command-line,
with the same sender, however you can use the '--from' flag to change that.

Emails are constructed with a static template, however it is possible to
customize the subject via a series of template-variables.  The default
subjects will be:

   --subject="[rss2email] #{ITEM.TITLE}"

Valid template values include:

  #{FEED.TITLE}
  #{FEED.LINK}
  #{ITEM.TITLE}
  #{ITEM.LINK}
  #{ITEM.AUTHOR.NAME}
  #{ITEM.AUTHOR.EMAIL}

  -from string
    	Specify the sending email address to use.
  -send
    	Should we send emails, or just pretend to? (default true)
  -subject string
    	A format string used to generate the email subject. (default "[rss2email] $ITEM.TITLE")
  -verbose
    	Should we be extra verbose?
```

If merged this would close #16.