### PR TITLE
Put subject in second html link

### DIFF
--- a/email_send.go
+++ b/email_send.go
@@ -61,7 +61,7 @@ Content-Transfer-Encoding: quoted-printable
 
 <p><a href=3D"{{quoteprintable .Link}}">{{quoteprintable .Subject}}</a></p>
 {{.HTML}}
-<p><a href=3D"{{quoteprintable .Link}}">{{quoteprintable .Link}}</a></p>
+<p><a href=3D"{{quoteprintable .Link}}">{{quoteprintable .Subject}}</a></p>
 --4186c39e13b2140c88094b3933206336f2bb3948db7ecf064c7a7d7473f2--
 
 --76a1282373c08a65dd49db1dea2c55111fda9a715c89720a844fabb7d497--


### PR DESCRIPTION
Only the first anchor for the item has .Subject as its text.  This commit puts the subject into the second anchor.