### PR TITLE
Call sendmail with -i option

### DIFF
--- a/email_send.go
+++ b/email_send.go
@@ -184,7 +184,7 @@ func SendMail(feed *gofeed.Feed, item withstate.FeedItem, addresses []string, te
 		// Prepare to run sendmail, with a pipe we can write our
 		// message to.
 		//
-		sendmail := exec.Command("/usr/sbin/sendmail", "-f", addr, addr)
+		sendmail := exec.Command("/usr/sbin/sendmail", "-i", "-f", addr, addr)
 		stdin, err := sendmail.StdinPipe()
 		if err != nil {
 			fmt.Printf("Error sending email: %s\n", err.Error())


### PR DESCRIPTION
By default, sendmail stops reading input when it encounters a line
containing a single '.' character.  This is rare in normal text,
but can happen in a quoted-printable encoding when a line is broken
just before the terminating '.'.  I saw it happen on a random rss
feed item. The -i option causes sendmail to process such lines
normally