### PR TITLE
28 duplication

### DIFF
--- a/feedlist/feedlist_test.go
+++ b/feedlist/feedlist_test.go
@@ -152,3 +152,43 @@ func TestWriteFailure(t *testing.T) {
 		t.Fatalf("expected an error, but got none")
 	}
 }
+
+// TestDuplication ensures we don't duplicate feeds.
+func TestDuplication(t *testing.T) {
+
+	// Create a temporary file
+	file, err := ioutil.TempFile(os.TempDir(), "testsave")
+	if err != nil {
+		t.Fatalf("failed to make temporary file: %s", err.Error())
+	}
+	defer os.Remove(file.Name())
+
+	// Create a new feed
+	list := New(file.Name())
+
+	// Add the same item multiple times
+	list.Add("https://example.com/foo.atom")
+	list.Add("https://example.com/foo.atom")
+	list.Add("https://example.com/foo.atom")
+	list.Add("https://example.com/foo.atom")
+	list.Add("https://example.com/foo.atom")
+	list.Add("https://example.com/foo.atom")
+
+	// Save it to disk
+	err = list.Save()
+	if err != nil {
+		t.Fatalf("failed to save feed list: %s", err)
+	}
+
+	// The file should now have contents - we can reload it
+	// and confirm
+	updated := New(file.Name())
+	found := updated.Entries()
+
+	if len(found) != 1 {
+		t.Errorf("expected one entry, found %d", len(found))
+	}
+	if found[0] != "https://example.com/foo.atom" {
+		t.Errorf("unexpected entry found: %s", found[0])
+	}
+}

--- a/withstate/feeditem.go
+++ b/withstate/feeditem.go
@@ -24,7 +24,7 @@ type FeedItem struct {
 	*gofeed.Item
 }
 
-// IsNew reports whether this particular feed-item new.
+// IsNew reports whether this particular feed-item is new.
 func (item *FeedItem) IsNew() bool {
 
 	file := item.path()
@@ -34,7 +34,7 @@ func (item *FeedItem) IsNew() bool {
 	return false
 }
 
-// RecordSeen updates this item, to record the entry has haven been seen.
+// RecordSeen updates this item, to record the fact that it has been seen.
 func (item *FeedItem) RecordSeen() {
 
 	// Get the file-path


### PR DESCRIPTION
Store our feeds in a map, to avoid duplicate entries
    
This pull-request changes the internal storage of our feed-list to use a map rather than an array, which has the desirable side-effect of removing duplicate entries.
    
This closes #28.
