### PR TITLE
Retain comments in the feeds file

### DIFF
--- a/list_cmd.go
+++ b/list_cmd.go
@@ -74,12 +74,7 @@ func (p *listCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) 
 	// Get the feed-list, from the default location.
 	list := feedlist.New("")
 
-	// For each entry in the list ..
-	for _, uri := range list.Entries() {
-
-		// Print it
-		fmt.Printf("%s\n", uri)
-	}
+	list.WriteAllEntriesIncludingComments(os.Stdout)
 
 	return subcommands.ExitSuccess
 }


### PR DESCRIPTION
We assume that all comment and blank lines in the feeds file are
associated with the feed url that follows them.  We maintain
those comments and list or delete them when the url is listed
or deleted.  When a new feed url is added, a comment is added
that consists of the feed's Title.

These default Title comments can be created for a current feedlist
by the following command:
    cd ~/.rss2email && mv feeds feeds.tmp &&
        rss2email add $(grep '^[^#]' feeds.tmp) && rm feeds.tmp