### PR TITLE
Retry fetches

### DIFF
--- a/cron_cmd.go
+++ b/cron_cmd.go
@@ -31,7 +31,7 @@ func (p *cronCmd) ProcessURL(input string) error {
 	// Fetch the feed for the input URL
 	feed, err := feedlist.Feed(input)
 	if err != nil {
-		return fmt.Errorf("error parsing %s contents: %s", input, err.Error())
+		return err
 	}
 
 	if p.verbose {

--- a/cron_cmd.go
+++ b/cron_cmd.go
@@ -135,7 +135,7 @@ Flags:
 }
 
 //
-// Flag setup: NOP
+// Flag setup
 //
 func (p *cronCmd) SetFlags(f *flag.FlagSet) {
 	f.BoolVar(&p.verbose, "verbose", false, "Should we be extra verbose?")

--- a/feedlist/feedlist.go
+++ b/feedlist/feedlist.go
@@ -12,6 +12,7 @@ import (
 	"os/user"
 	"path"
 	"strings"
+	"time"
 
 	"github.com/mmcdole/gofeed"
 )
@@ -43,8 +44,7 @@ func fetchFeed(url string) (string, error) {
 	return string(output), nil
 }
 
-// Feed takes an URL as input, and returns a *gofeed.Feed.
-func Feed(url string) (*gofeed.Feed, error) {
+func fetchFeedAndParse(url string) (*gofeed.Feed, error) {
 
 	// Fetch the URL
 	txt, err := fetchFeed(url)
@@ -60,6 +60,25 @@ func Feed(url string) (*gofeed.Feed, error) {
 	}
 
 	return feed, nil
+}
+
+// Feed takes an URL as input, and returns a *gofeed.Feed.
+func Feed(url string) (*gofeed.Feed, error) {
+	var feed *gofeed.Feed
+	var err error
+
+	// Try up to 5 times
+	for i := 0; i < 5; i++ {
+		feed, err = fetchFeedAndParse(url)
+		if err == nil {
+			return feed, nil
+		}
+
+		// Rate limit to avoid hammering the server
+		time.Sleep(1 * time.Second)
+	}
+
+	return nil, err
 }
 
 // expandedEntry is a url with its comment from the feeds file.

--- a/list_cmd.go
+++ b/list_cmd.go
@@ -47,7 +47,7 @@ Flags:
 }
 
 //
-// Flag setup: NOP
+// Flag setup
 //
 func (p *listCmd) SetFlags(f *flag.FlagSet) {
 	f.BoolVar(&p.template, "template", false, "Show the contents of the default template?")


### PR DESCRIPTION
On a feed fetch error, we retry fetching in case the error was transient.

They're relatively rare, but I've seen several feed fetch/parse operations that failed only to
succeed on immediate retry of the fetch/parse.  I've seen some fail twice in succession
(at one-second intervals), but succeed the third time.

I included a couple of trivial commits.