### PR TITLE
Call RecordSeen even if the entry was seen before

### DIFF
--- a/cron_cmd.go
+++ b/cron_cmd.go
@@ -75,15 +75,15 @@ func (p *cronCmd) ProcessURL(input string) error {
 					return err
 				}
 			}
-
-			// Mark the item as having been seen, after the
-			// email was sent.
-			//
-			// This does run the risk that sending mail
-			// fails, due to error, and that keeps happening
-			// forever...
-			item.RecordSeen()
 		}
+
+		// Mark the item as having been seen, after the
+		// email was sent.
+		//
+		// This does run the risk that sending mail
+		// fails, due to error, and that keeps happening
+		// forever...
+		item.RecordSeen()
 	}
 
 	return nil

--- a/withstate/feeditem.go
+++ b/withstate/feeditem.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"os/user"
 	"path"
+	"time"
 
 	"github.com/mmcdole/gofeed"
 )
@@ -39,6 +40,12 @@ func (item *FeedItem) RecordSeen() {
 
 	// Get the file-path
 	file := item.path()
+
+	if _, err := os.Stat(file); os.IsExist(err) {
+		t := time.Now()
+		_ = os.Chtimes(file, t, t)
+		return
+	}
 
 	// Ensure the parent directory exists
 	dir, _ := path.Split(file)


### PR DESCRIPTION
We unconditionally record the feed entry as seen whenever it appears
in a feed.  This will permit us to identify entries that no longer
appear in feeds, so we know it's safe to remove their state files.

We can then experiment with pruning stale state files.