### PR TITLE
Reduce the delay fetching a bad feed url

### DIFF
--- a/feedlist/feedlist.go
+++ b/feedlist/feedlist.go
@@ -62,20 +62,25 @@ func fetchFeedAndParse(url string) (*gofeed.Feed, error) {
 	return feed, nil
 }
 
+const (
+	fetchMaxTries   = 5
+	fetchRetryDelay = 200 * time.Millisecond
+)
+
 // Feed takes an URL as input, and returns a *gofeed.Feed.
 func Feed(url string) (*gofeed.Feed, error) {
 	var feed *gofeed.Feed
 	var err error
 
-	// Try up to 5 times
-	for i := 0; i < 5; i++ {
+	// Try up to fetchMaxTries times
+	for i := 0; i < fetchMaxTries; i++ {
+		// Rate limit to avoid hammering the server
+		time.Sleep(time.Duration(i) * fetchRetryDelay)
+
 		feed, err = fetchFeedAndParse(url)
 		if err == nil {
 			return feed, nil
 		}
-
-		// Rate limit to avoid hammering the server
-		time.Sleep(1 * time.Second)
 	}
 
 	return nil, err


### PR DESCRIPTION
Currently, the delay introduced when adding a bogus feed url
exceeds 5 seconds.  This commit reduces the delay to a little
over 0.8 seconds.  This is done primarily by reducing the delay
before retrying to 200 mS.  Also, we remove one needless delay
after the last attempt.