### PR TITLE
Prune stale state files

### DIFF
--- a/cron_cmd.go
+++ b/cron_cmd.go
@@ -186,6 +186,15 @@ func (p *cronCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) 
 		}
 	}
 
+	prunedCount, pruneErrors := withstate.PruneStateFiles()
+	for _, err := range pruneErrors {
+		errors = append(errors, err.Error())
+	}
+
+	if p.verbose && prunedCount > 0 {
+		fmt.Printf("Pruned %d entry state files\n", prunedCount)
+	}
+
 	//
 	// If we found errors then handle that.
 	//


### PR DESCRIPTION
Remove state files for feed entries that havent been seen in 25 hours.
I chose 25 hours so that if we are running rss2email daily, we will
have guaranteed two chances to see the feed entry before removing its
state file.

I've run this long enough to see a dozen stale state files pruned.