### PR TITLE
Handle feed entries without a GUID

### DIFF
--- a/withstate/feeditem.go
+++ b/withstate/feeditem.go
@@ -81,9 +81,14 @@ func stateDirectory() string {
 // the seen vs. unseen state of a particular entry.
 func (item *FeedItem) path() string {
 
+	guid := item.GUID
+	if guid == "" {
+		guid = item.Link
+	}
+
 	// Hash the item GUID
 	hasher := sha1.New()
-	hasher.Write([]byte(item.GUID))
+	hasher.Write([]byte(guid))
 	hashBytes := hasher.Sum(nil)
 
 	// Hexadecimal conversion


### PR DESCRIPTION
If the feed entry's GUID is null, use the sha1 of the entry's link
as the state file name.

Without this commit when the entries for a feed have no GUID, the sha1 of the null GUID for all entries is identical.  This causes all entries to have the same state file.  Work around this by hashing the entry's Link instead.