### PR TITLE
Fix updating mtime for existing state files

### DIFF
--- a/withstate/feeditem.go
+++ b/withstate/feeditem.go
@@ -41,7 +41,7 @@ func (item *FeedItem) RecordSeen() {
 	// Get the file-path
 	file := item.path()
 
-	if _, err := os.Stat(file); os.IsExist(err) {
+	if _, err := os.Stat(file); !os.IsNotExist(err) {
 		t := time.Now()
 		_ = os.Chtimes(file, t, t)
 		return


### PR DESCRIPTION
As it was written, the test was always false and the mtime was
never updated.  Instead, the file was overwritten with the same
contents it contained before.  This worked but was inefficient.