### PR TITLE
Moved code around to make future development simpler

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ If you're a developer who wishes to submit changes to the embedded version you s
 * First of all edit `data/email.tmpl`, this is the source of the template.
 * Next run the [implant](https://github.com/skx/implant) tool.
   * This is responsible for reading the file, and embedding it into the file `static.go`, which is then included in the binary when the project is compiled.
+  * You'll run `implant -package template -output ./template/static.go`
 * Rebuild the application to update the embedded copy `go build .`
   * This will ensure that the changes you made to `data/email.tmpl` are actually contained within your binary, and will be used the next time you launch it.
 

--- a/list_cmd.go
+++ b/list_cmd.go
@@ -10,6 +10,7 @@ import (
 	"os"
 
 	"github.com/skx/rss2email/feedlist"
+	"github.com/skx/rss2email/template"
 )
 
 // Structure for our options and state.
@@ -56,7 +57,7 @@ func (l *listCmd) Execute(args []string) int {
 	if l.template {
 
 		// Load the default template from the embedded resource.
-		content, err := getResource("data/email.tmpl")
+		content, err := template.EmailTemplate()
 		if err != nil {
 			fmt.Printf("failed to load embedded resource: %s\n", err.Error())
 			os.Exit(1)

--- a/processor/email_send.go
+++ b/processor/email_send.go
@@ -4,7 +4,7 @@
 // have both a text and a HTML part to it.
 //
 
-package main
+package processor
 
 import (
 	"bytes"
@@ -20,6 +20,7 @@ import (
 	"text/template"
 
 	"github.com/mmcdole/gofeed"
+	emailtemplate "github.com/skx/rss2email/template"
 	"github.com/skx/rss2email/withstate"
 )
 
@@ -38,7 +39,7 @@ func setupTemplate() *template.Template {
 	}
 
 	// Load the default template from the embedded resource.
-	content, err := getResource("data/email.tmpl")
+	content, err := emailtemplate.EmailTemplate()
 	if err != nil {
 		fmt.Printf("failed to load embedded resource: %s\n", err.Error())
 		os.Exit(1)

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -1,0 +1,142 @@
+package processor
+
+import (
+	"fmt"
+
+	"github.com/k3a/html2text"
+	"github.com/skx/rss2email/feedlist"
+	"github.com/skx/rss2email/withstate"
+)
+
+// Processor stores our state
+type Processor struct {
+
+	// send controls whether we send emails, or just pretend to.
+	send bool
+
+	// verbose denotes how verbose we should be in execution.
+	verbose bool
+}
+
+// New creates a new Processor object
+func New() *Processor {
+	return &Processor{send: true}
+}
+
+// ProcessFeeds is the main workhorse here, we process each feed and send
+// emails appropriately.
+func (p *Processor) ProcessFeeds(recipients []string) []error {
+
+	//
+	// If we receive errors we'll store them here,
+	// so we can keep processing subsequent URIs.
+	//
+	var errors []error
+
+	// Get the feed-list, from the default location.
+	list := feedlist.New("")
+
+	// For each entry in the list ..
+	for _, uri := range list.Entries() {
+
+		// Handle it.
+		err := p.processURL(uri, recipients)
+		if err != nil {
+			errors = append(errors, fmt.Errorf("error processing %s - %s", uri, err))
+		}
+	}
+
+	prunedCount, pruneErrors := withstate.PruneStateFiles()
+	for _, err := range pruneErrors {
+		errors = append(errors, err)
+	}
+
+	if p.verbose && prunedCount > 0 {
+		fmt.Printf("Pruned %d entry state files\n", prunedCount)
+	}
+
+	return errors
+}
+
+// processURL takes an URL as input, fetches the contents, and then
+// processes each feed item found within it.
+//
+// Feed items which are new/unread will generate an email.
+func (p *Processor) processURL(input string, recipients []string) error {
+
+	// Show what we're doing.
+	if p.verbose {
+		fmt.Printf("Fetching: %s\n", input)
+	}
+
+	// Fetch the feed for the input URL
+	feed, err := feedlist.Feed(input)
+	if err != nil {
+		return err
+	}
+
+	if p.verbose {
+		fmt.Printf("\tFound %d entries\n", len(feed.Items))
+	}
+
+	// For each entry in the feed ..
+	for _, xp := range feed.Items {
+
+		// Wrap it so we can use our helper methods
+		item := withstate.FeedItem{Item: xp}
+
+		// If we've not already notified about this one.
+		if item.IsNew() {
+
+			// Show the new item.
+			if p.verbose {
+				fmt.Printf("\t\tNew Entry: %s\n", item.Title)
+			}
+
+			// If we're supposed to send email then do that
+			if p.send {
+
+				// The body should be stored in the
+				// "Content" field.
+				content := item.Content
+
+				// If the Content field is empty then
+				// use the Description instead, if it
+				// is non-empty itself.
+				if (content == "") && item.Description != "" {
+					content = item.Description
+				}
+
+				// Convert the content to text.
+				text := html2text.HTML2Text(content)
+
+				// Send the mail
+				err := SendMail(feed, item, recipients, text, content)
+				if err != nil {
+					return err
+				}
+			}
+		}
+
+		// Mark the item as having been seen, after the
+		// email was sent.
+		//
+		// This does run the risk that sending mail
+		// fails, due to error, and that keeps happening
+		// forever...
+		item.RecordSeen()
+	}
+
+	return nil
+}
+
+// SetVerbose updates the verbosity state of this object.
+func (p *Processor) SetVerbose(state bool) {
+	p.verbose = state
+}
+
+// SetSendEmail updates the state of this object, when the send-flag
+// is false zero emails are generated.
+func (p *Processor) SetSendEmail(state bool) {
+	p.send = state
+}

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -1,3 +1,6 @@
+// Package processor contains the code which will actually poll
+// the list of URLs the user is watching, and send emails for those
+// entries which are new.
 package processor
 
 import (
@@ -46,11 +49,13 @@ func (p *Processor) ProcessFeeds(recipients []string) []error {
 		}
 	}
 
+	// Prune old state files
 	prunedCount, pruneErrors := withstate.PruneStateFiles()
-	for _, err := range pruneErrors {
-		errors = append(errors, err)
-	}
 
+	// If we got any errors propagate them
+	errors = append(errors, pruneErrors...)
+
+	// Show what we did, if we should
 	if p.verbose && prunedCount > 0 {
 		fmt.Printf("Pruned %d entry state files\n", prunedCount)
 	}

--- a/template/static.go
+++ b/template/static.go
@@ -3,7 +3,8 @@
 //
 // Local edits will be lost.
 //
-package main
+
+package template
 
 import (
 	"bytes"

--- a/template/template.go
+++ b/template/template.go
@@ -1,0 +1,11 @@
+// Package template just holds our email-template.
+//
+// This is abstracted because we want to refer to it from our
+// processor-package, which is not in package-main, and also
+// the template-listing command.
+package template
+
+// EmailTemplate returns the embedded email template.
+func EmailTemplate() ([]byte, error) {
+	return getResource("data/email.tmpl")
+}

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -1,0 +1,116 @@
+//
+// Simple testing of our embedded resource.
+//
+
+package template
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+//
+// Test that we have one embedded resource.
+//
+func TestResourceCount(t *testing.T) {
+
+	expected := 0
+
+	// We're going to compare what is embedded with
+	// what is on-disk.
+	//
+	// We could just hard-wire the count, but that
+	// would require updating the count every time
+	// we add/remove a new resource
+	err := filepath.Walk("../data",
+		func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			if !info.IsDir() {
+				expected++
+			}
+			return nil
+		})
+	if err != nil {
+		t.Errorf("failed to find resources beneath data/ %s", err.Error())
+	}
+
+	if expected != 1 {
+		t.Fatalf("we expected 1 template-file beneath data/")
+	}
+
+	out := getResources()
+
+	if len(out) != expected {
+		t.Errorf("We expected %d resources but found %d.", expected, len(out))
+	}
+}
+
+//
+// Test that each of our resources is identical to the master
+// version.
+//
+func TestResourceMatches(t *testing.T) {
+
+	//
+	// For each resource
+	//
+	all := getResources()
+
+	for _, entry := range all {
+
+		//
+		// Get the data from our embedded copy
+		//
+		data, err := getResource(entry.Filename)
+		if err != nil {
+			t.Errorf("Loading our resource failed:%s", entry.Filename)
+		}
+
+		//
+		// Get the data from our master-copy.
+		//
+		master, err := ioutil.ReadFile("../" + entry.Filename)
+		if err != nil {
+			t.Errorf("Loading our master-resource failed:%s", entry.Filename)
+		}
+
+		//
+		// Test the lengths match
+		//
+		if len(master) != len(data) {
+			t.Errorf("Embedded and real resources have different sizes.")
+		}
+
+		//
+		// Test the data-matches
+		//
+		if string(master) != string(data) {
+			t.Errorf("Embedded and real resources have different content.")
+		}
+	}
+}
+
+//
+// Test that a missing resource is handled.
+//
+func TestMissingResource(t *testing.T) {
+
+	//
+	// Get the data from our embedded copy
+	//
+	data, err := getResource("moi/kissa")
+	if data != nil {
+		t.Errorf("We expected to find no data, but got some.")
+	}
+	if err == nil {
+		t.Errorf("We expected an error loading a missing resource, but got none.")
+	}
+	if !strings.Contains(err.Error(), "failed to find resource") {
+		t.Errorf("Error message differed from expectations.")
+	}
+}


### PR DESCRIPTION
This merge-request updates #49, by moving the code around to
make adding SMTP-support simpler.

* Moved the feed-walking, and email-generating to the `processor/` package.
* Moved the email-template into a (trivial) package so that we can refer
to it from multiple locations