### PR TITLE
Support Windows

### DIFF
--- a/feedlist/feedlist.go
+++ b/feedlist/feedlist.go
@@ -10,7 +10,7 @@ import (
 	"net/http"
 	"os"
 	"os/user"
-	"path"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -131,7 +131,7 @@ func New(filename string) *FeedList {
 		}
 
 		// Now build up our file-path
-		filename = path.Join(home, ".rss2email", "feeds")
+		filename = filepath.Join(home, ".rss2email", "feeds")
 	}
 
 	// Save our updated filename
@@ -242,7 +242,7 @@ func (f *FeedList) Save() error {
 
 	// Of course we need to make sure the directory exists before
 	// we can write beneath it.
-	dir, _ := path.Split(f.filename)
+	dir, _ := filepath.Split(f.filename)
 	os.MkdirAll(dir, os.ModePerm)
 
 	// Open the file

--- a/processor/emailer/emailer.go
+++ b/processor/emailer/emailer.go
@@ -22,7 +22,7 @@ import (
 	"os"
 	"os/exec"
 	"os/user"
-	"path"
+	"path/filepath"
 	"strconv"
 	"text/template"
 
@@ -72,7 +72,7 @@ func (e *Emailer) loadTemplate() (*template.Template, error) {
 	}
 
 	// The path to the overridden template
-	override := path.Join(home, ".rss2email", "email.tmpl")
+	override := filepath.Join(home, ".rss2email", "email.tmpl")
 
 	// If the file exists, use it.
 	_, err = os.Stat(override)


### PR DESCRIPTION
Hi, author.

I made a boot start on Windows, things working fine except missing directory error and some mixed style path string in error message. Thus a `os.MkdirAll` is added and `path` replaced as `filepath`.