### PR TITLE
Improve testing of our project

### DIFF
--- a/httpfetch/httpfetch.go
+++ b/httpfetch/httpfetch.go
@@ -1,0 +1,101 @@
+// Package httpfetch makes a remote HTTP call to retrieve an URL,
+// and parse that into a series of feed-items
+//
+// It is abstracted into its own class to allow testing.
+package httpfetch
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"time"
+
+	"github.com/mmcdole/gofeed"
+)
+
+const ()
+
+// HTTPFetch is our state-storing structure
+type HTTPFetch struct {
+
+	// The URL we should fetch
+	url string
+
+	// Contents of the remote URL, used for testing
+	content string
+
+	// How many times we should attempt to retry a failed
+	// fetch before giving up.
+	maxRetries int
+
+	// Between retries we should delay to avoid overwhelming
+	// the remote server.  This specifies how many times we should
+	// do that.
+	retryDelay time.Duration
+}
+
+// New creates a new object which will fetch our content
+func New(url string) *HTTPFetch {
+	return &HTTPFetch{url: url,
+		maxRetries: 5,
+		retryDelay: 200 * time.Millisecond,
+	}
+}
+
+// Fetch performs the HTTP-fetch, and returns the feed-contents.
+//
+// If the `content` field is non-empty it will be used in preference
+// to the remote URLs content, for testing.
+func (h *HTTPFetch) Fetch() (*gofeed.Feed, error) {
+
+	var feed *gofeed.Feed
+	var err error
+
+	// Download contents, if not already present.
+	for i := 0; h.content == "" && i < h.maxRetries; i++ {
+
+		err = h.fetch()
+		if err == nil {
+			break
+		}
+		time.Sleep(time.Duration(i) * h.retryDelay)
+	}
+
+	// Failed, after all the retries?
+	if err != nil {
+		return feed, err
+	}
+
+	// Parse it
+	fp := gofeed.NewParser()
+	feed, err2 := fp.ParseString(h.content)
+	if err2 != nil {
+		return nil, fmt.Errorf("error parsing %s contents: %s", h.url, err2.Error())
+	}
+
+	return feed, nil
+}
+
+// fetchURL fetches the text from the remote URL.
+func (h *HTTPFetch) fetch() error {
+
+	// Create a HTTP-client
+	client := &http.Client{}
+	req, err := http.NewRequest("GET", h.url, nil)
+	if err != nil {
+		return err
+	}
+
+	// Make the request, with a valid user-agent
+	req.Header.Set("User-Agent", "rss2email (https://github.com/skx/rss2email)")
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	// save the result
+	data, err2 := ioutil.ReadAll(resp.Body)
+	h.content = string(data)
+	return err2
+}

--- a/httpfetch/httpfetch_test.go
+++ b/httpfetch/httpfetch_test.go
@@ -1,0 +1,132 @@
+package httpfetch
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/skx/rss2email/withstate"
+)
+
+// TestNonFeed confirms we can cope with a remote URL which is not a feed.
+func TestNonFeed(t *testing.T) {
+
+	// Not a feed.
+	x := New("http://example.com/")
+	x.content = "this is not an XML file, so not a feed"
+
+	// Parse it, which should fail.
+	_, err := x.Fetch()
+	if err == nil {
+		t.Fatalf("We expected error, but got none!")
+	}
+
+	// And confirm it fails in the correct way.
+	if !strings.Contains(err.Error(), "Failed to detect feed type") {
+		t.Fatalf("got an error, but not what we expected; %s", err.Error())
+	}
+}
+
+// TestOneEntry confirms a feed contains a single entry
+func TestOneEntry(t *testing.T) {
+
+	// The contents of our feed.
+	x := New("https://blog.steve.fi/index.rss")
+	x.content = `<?xml version="1.0"?>
+<rdf:RDF
+ xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+ xmlns:dc="http://purl.org/dc/elements/1.1/"
+ xmlns:foaf="http://xmlns.com/foaf/0.1/"
+ xmlns:content="http://purl.org/rss/1.0/modules/content/"
+ xmlns="http://purl.org/rss/1.0/"
+>
+<channel rdf:about="https://blog.steve.fi/">
+<title>Steve Kemp&#39;s Blog</title>
+<link>https://blog.steve.fi/</link>
+<description>Debian and Free Software</description>
+<items>
+ <rdf:Seq>
+  <rdf:li rdf:resource="https://blog.steve.fi/brexit_has_come.html"/>
+ </rdf:Seq>
+</items>
+</channel>
+
+<item rdf:about="https://blog.steve.fi/brexit_has_come.html">
+  <title>Brexit has come</title>
+  <link>https://blog.steve.fi/brexit_has_come.html</link>
+  <guid>https://blog.steve.fi/brexit_has_come.html</guid>
+  <content:encoded>Hello, World</content:encoded>
+  <dc:date>2020-05-22T09:00:00Z</dc:date>
+</item>
+</rdf:RDF>
+`
+
+	// Parse it which should not fail.
+	out, err := x.Fetch()
+	if err != nil {
+		t.Fatalf("We didn't expect an error, but found %s", err.Error())
+	}
+
+	// Confirm there is a single entry.
+	if len(out.Items) != 1 {
+		t.Fatalf("Expected one entry, but got %d", len(out.Items))
+	}
+}
+
+// TestRewrite ensures that a broken file is rewriting
+func TestRewrite(t *testing.T) {
+
+	// The contents of our feed.
+	x := New("https://blog.steve.fi/index.rss")
+	x.content = `<?xml version="1.0"?>
+<rdf:RDF
+ xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+ xmlns:dc="http://purl.org/dc/elements/1.1/"
+ xmlns:foaf="http://xmlns.com/foaf/0.1/"
+ xmlns:content="http://purl.org/rss/1.0/modules/content/"
+ xmlns="http://purl.org/rss/1.0/"
+>
+<channel rdf:about="https://blog.steve.fi/">
+<title>Steve Kemp&#39;s Blog</title>
+<link>https://blog.steve.fi/</link>
+<description>Debian and Free Software</description>
+<items>
+ <rdf:Seq>
+  <rdf:li rdf:resource="https://blog.steve.fi/brexit_has_come.html"/>
+ </rdf:Seq>
+</items>
+</channel>
+
+<item rdf:about="https://blog.steve.fi/brexit_has_come.html">
+  <title>Brexit has come</title>
+  <link>https://blog.steve.fi/brexit_has_come.html</link>
+  <guid>https://blog.steve.fi/brexit_has_come.html</guid>
+  <content:encoded>&lt;a href="/foo"&gt;Foo&lt;/a&gt;</content:encoded>
+  <dc:date>2020-05-22T09:00:00Z</dc:date>
+</item>
+</rdf:RDF>
+`
+
+	// Parse it which should not fail.
+	out, err := x.Fetch()
+	if err != nil {
+		t.Fatalf("We didn't expect an error, but found %s", err.Error())
+	}
+
+	// Confirm there is a single entry.
+	if len(out.Items) != 1 {
+		t.Fatalf("Expected one entry, but got %d", len(out.Items))
+	}
+
+	// Get the parsed-content
+	item := withstate.FeedItem{Item: out.Items[0]}
+	content, err := item.HTMLContent()
+	if err != nil {
+		t.Fatalf("unexpected error on item content: %v", err)
+	}
+
+	// Confirm that contains : href="https://blog.steve.fi/foo",
+	// not: href="/foo"
+	if strings.Contains(content, "\"/foo") {
+		t.Fatalf("Failed to expand URLS: %s", content)
+	}
+}

--- a/withstate/feeditem.go
+++ b/withstate/feeditem.go
@@ -88,10 +88,10 @@ func (item *FeedItem) HTMLContent() (string, error) {
 	if err != nil {
 		return rawContent, err
 	}
-	doc.Find("img, link").Each(func(i int, e *goquery.Selection) {
+	doc.Find("a, img").Each(func(i int, e *goquery.Selection) {
 		var attr string
 		switch e.Get(0).Data {
-		case "link":
+		case "a":
 			attr = "href"
 		case "img":
 			attr = "src"


### PR DESCRIPTION
This pull-request moves the HTTP-fetching of our remote HTTP-feed
into its own package, so that it can be tested.

Specifically here I'm looking at the testing of content-rewriting
which was added in #57

* **BUGFIX** The rewriting did not rewrite LINKS
  * Because it looked for `link`, rather than `a`.

This closes #60.