### PR TITLE
63 include filtering

### DIFF
--- a/config_cmd.go
+++ b/config_cmd.go
@@ -43,12 +43,14 @@ About
 -----
 
 RSS2Email is a simple command-line utility which will fetch items from
-remote Atom and RSS feeds and generate emails.  In order to operate it
-obviously needs a list of locations to poll.
+remote Atom and RSS feeds and generate emails.
+
+In order to operate it needs a list of remote Atom/RSS feeds to
+process, which are stored in a configuration file.
 
 
-Config Location
----------------
+Configuration File Location
+---------------------------
 
 As of the 2.x series of rss2email releases the configuration file format
 and location have changed.  The new configuration file will be read from:
@@ -58,10 +60,12 @@ and location have changed.  The new configuration file will be read from:
 	if !exists {
 		doc += `
 
+NOTE:
 NOTE: The configuration file does not currently exist!
+NOTE:
 NOTE: The legacy file will be read if it is present.
 NOTE:
-NOTE: If nothing is present this application will do nothing useful!`
+`
 	}
 
 	doc += `
@@ -80,12 +84,13 @@ Entries can be commented out via the '#' character, temporarily:
        https://blog.steve.fi/index.rss
        # http://floooh.github.io/feed.xml
 
-In the future it will be possible to do more, and with that in mind there
-is scope for adding options which apply only to specific feeds.  The general
-form of this support looks like this:
+In addition to containing a list of feed-locations the configuration file
+allows per-feed configuration options to be set.  The general form of this
+support looks like this:
 
        https://foo.example.com/
         - key:value
+        - key:value2
        https://foo.example.com/
         - key2:value2
 
@@ -93,16 +98,20 @@ Here you see that lines prefixed with " -" will be used to specify a key
 and value separated with a ":" character.  Configuration-options apply to
 the URL above their appearance.
 
-Any option appearing before an URL is a fatal error, and will be reported
-as such.
+The first example demonstrates that configuration-keys may be repeated multiple
+times, if you desire.
 
-Available Options
-------------------
+As configuration-items refer to feeds it is a fatal error for such a thing
+to appear before a URL.
+
+Per-Feed Configuration Options
+------------------------------
 
 Key           | Purpose
 --------------+--------------------------------------------------------------
 exclude       | Exclude any item which matches the given regular-expression.
-exclude-title | Exclude any item title matching the given regular-expression.
+exclude-title | Exclude any item with title matching the given regular-expression.
+include       | Include ONLY items which match the given regular-expression.
 retry         | The maximum number of times to retry a failing HTTP-fetch.
 delay         | The amount of time to sleep between retried HTTP-fetches.
 `
@@ -114,7 +123,7 @@ func (c *configCmd) Execute(args []string) int {
 
 	fmt.Fprintf(out, "This command only exists to show help, when executed as:")
 	fmt.Fprintf(out, "\n")
-	fmt.Fprintf(out, "rss2email help config")
+	fmt.Fprintf(out, "\trss2email help config")
 	fmt.Fprintf(out, "\n")
 
 	// All done, with no errors.

--- a/config_cmd_test.go
+++ b/config_cmd_test.go
@@ -71,7 +71,6 @@ func TestMissingConfig(t *testing.T) {
 	//
 	expected := []string{
 		"The configuration file does not currently exist!",
-		"If nothing is present this application will do nothing useful!",
 		tmpfile.Name(),
 	}
 

--- a/configfile/configfile_test.go
+++ b/configfile/configfile_test.go
@@ -185,6 +185,39 @@ http://example.com/
 	os.Remove(c.path)
 }
 
+// TestComplexOption tests parsing an option containing ":"
+func TestComplexOption(t *testing.T) {
+
+	c := ParserHelper(t, `
+http://example.com/
+ - include:(?i)(foo:|bar:)
+`)
+
+	out, err := c.Parse()
+	if err != nil {
+		t.Fatalf("Error parsing file: %v", err)
+	}
+
+	// One entry
+	if len(out) != 1 {
+		t.Fatalf("parsed wrong number of entries, got %d\n%v", len(out), out)
+	}
+
+	// We should have one option
+	if len(out[0].Options) != 1 {
+		t.Fatalf("Found wrong number of options, got %d", len(out[0].Options))
+	}
+
+	if out[0].Options[0].Name != "include" {
+		t.Fatalf("unexpected option name")
+	}
+	if out[0].Options[0].Value != "(?i)(foo:|bar:)" {
+		t.Fatalf("unexpected option value")
+	}
+
+	os.Remove(c.path)
+}
+
 // TestBrokenOptions looks for options outside an URL
 func TestBrokenOptions(t *testing.T) {
 

--- a/httpfetch/httpfetch_test.go
+++ b/httpfetch/httpfetch_test.go
@@ -3,6 +3,7 @@ package httpfetch
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/skx/rss2email/configfile"
 	"github.com/skx/rss2email/withstate"
@@ -129,5 +130,52 @@ func TestRewrite(t *testing.T) {
 	// not: href="/foo"
 	if strings.Contains(content, "\"/foo") {
 		t.Fatalf("Failed to expand URLS: %s", content)
+	}
+}
+
+func TestDelay(t *testing.T) {
+
+	// Valid number
+	n := New(configfile.Feed{URL: "https://blog.steve.fi/index.rss",
+		Options: []configfile.Option{
+			{Name: "delay", Value: "15"},
+		}})
+
+	if n.retryDelay != 15*time.Millisecond {
+		t.Errorf("failed to parse delay value")
+	}
+
+	// Invalid number
+	i := New(configfile.Feed{URL: "https://blog.steve.fi/index.rss",
+		Options: []configfile.Option{
+			{Name: "delay", Value: "steve"},
+		}})
+
+	if i.retryDelay != 1000*time.Millisecond {
+		t.Errorf("bogus value changed our delay-value")
+	}
+}
+
+func TestRetry(t *testing.T) {
+
+	// Valid number
+	n := New(configfile.Feed{URL: "https://blog.steve.fi/index.rss",
+		Options: []configfile.Option{
+			{Name: "retry", Value: "33"},
+			{Name: "moi", Value: "3"},
+		}})
+
+	if n.maxRetries != 33 {
+		t.Errorf("failed to parse retry value")
+	}
+
+	// Invalid number
+	i := New(configfile.Feed{URL: "https://blog.steve.fi/index.rss",
+		Options: []configfile.Option{
+			{Name: "retry", Value: "steve"},
+		}})
+
+	if i.maxRetries != 3 {
+		t.Errorf("bogus value changed our default")
 	}
 }

--- a/processor/processor_test.go
+++ b/processor/processor_test.go
@@ -1,0 +1,111 @@
+package processor
+
+import (
+	"testing"
+
+	"github.com/skx/rss2email/configfile"
+)
+
+func TestSendEmail(t *testing.T) {
+
+	p := New()
+
+	if !p.send {
+		t.Fatalf("unexpected default to sending mail")
+	}
+
+	p.SetSendEmail(false)
+
+	if p.send {
+		t.Fatalf("unexpected send-setting")
+	}
+
+}
+
+func TestVerbose(t *testing.T) {
+
+	p := New()
+
+	if p.verbose {
+		t.Fatalf("unexpected default to verbose")
+	}
+
+	p.SetVerbose(true)
+
+	if !p.verbose {
+		t.Fatalf("unexpected verbose setting")
+	}
+}
+
+// TestSkipExclude ensures that we can exclude items by regexp
+func TestSkipExclude(t *testing.T) {
+
+	feed := configfile.Feed{
+		URL: "blah",
+		Options: []configfile.Option{
+			configfile.Option{Name: "exclude", Value: "foo"},
+			configfile.Option{Name: "exclude-title", Value: "test"},
+		},
+	}
+
+	// Create the new processor
+	x := New()
+
+	// Set it as verbose
+	x.SetVerbose(true)
+
+	if !x.shouldSkip(feed, "Title here", "<p>foo, bar baz</p>") {
+		t.Fatalf("failed to skip entry by regexp")
+	}
+
+	if !x.shouldSkip(feed, "test", "<p>This matches the title</p>") {
+		t.Fatalf("failed to skip entry by title")
+	}
+
+	// With no options we're not going to skip
+	feed = configfile.Feed{
+		URL:     "blah",
+		Options: []configfile.Option{},
+	}
+
+	if x.shouldSkip(feed, "Title here", "<p>foo, bar baz</p>") {
+		t.Fatalf("skipped something with no options!")
+	}
+
+}
+
+// TestSkipInclude ensures that we can exclude items by regexp
+func TestSkipInclude(t *testing.T) {
+
+	feed := configfile.Feed{
+		URL: "blah",
+		Options: []configfile.Option{
+			configfile.Option{Name: "include", Value: "good"},
+		},
+	}
+
+	// Create the new processor
+	x := New()
+
+	// Set it as verbose
+	x.SetVerbose(true)
+
+	if x.shouldSkip(feed, "Title here", "<p>This is good</p>") {
+		t.Fatalf("this should be included because it contains good")
+	}
+
+	if !x.shouldSkip(feed, "Title here", "<p>This should be excluded.</p>") {
+		t.Fatalf("This should be excluded; doesn't contain 'good'")
+	}
+
+	// If we don't try to make a mandatory include setting
+	// nothing should be skipped
+	feed = configfile.Feed{
+		URL:     "blah",
+		Options: []configfile.Option{},
+	}
+
+	if x.shouldSkip(feed, "Title here", "<p>This is good</p>") {
+		t.Fatalf("nothing specified, shouldn't be skipped")
+	}
+}


### PR DESCRIPTION
This pull-request closes #63, by allowing the support for the reverse of excluding entries.
    
The following setting ensures that any entry in a feed containing the term `foo` is not emailed:
    
            - exclude: foo
    
As a result of this pull-request we now support:
    
            http://example.com/feed/
              - include: bar
    
This will only email entries from the given feed that match the regular expression bar.
