### PR TITLE
66 include with titles

### DIFF
--- a/config_cmd.go
+++ b/config_cmd.go
@@ -111,9 +111,25 @@ Key           | Purpose
 --------------+--------------------------------------------------------------
 exclude       | Exclude any item which matches the given regular-expression.
 exclude-title | Exclude any item with title matching the given regular-expression.
-include       | Include ONLY items which match the given regular-expression.
+include       | Include only items which match the given regular-expression.
+include-title | Include only items with title matching the given regular-expression.
 retry         | The maximum number of times to retry a failing HTTP-fetch.
 delay         | The amount of time to sleep between retried HTTP-fetches.
+
+
+Regular Expression Tips
+-----------------------
+
+Regular expressions are case-sensitive by default, to make them ignore any
+differences in case prefix them with "(?i)".
+
+For example the following entry will ignore any feed-items containing the
+word "cake" in their titles regardless of whether it is written as "cake",
+"Cake", or some other combination of upper and lower-cased letters:
+
+      https://example.com/feed/path/here
+       - exclude-title: (?i)cake
+
 `
 	return name, doc
 }

--- a/config_cmd_test.go
+++ b/config_cmd_test.go
@@ -72,6 +72,12 @@ func TestMissingConfig(t *testing.T) {
 	expected := []string{
 		"The configuration file does not currently exist!",
 		tmpfile.Name(),
+
+		// known configuration options
+		"include ",
+		"include-title",
+		"exclude ",
+		"exclude-title",
 	}
 
 	for _, txt := range expected {

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -219,6 +219,23 @@ func (p *Processor) shouldSkip(config configfile.Feed, title string, content str
 	include := false
 
 	for _, opt := range config.Options {
+		if opt.Name == "include-title" {
+
+			// We found (at least one) include option
+			include = true
+
+			// OK we've found a `include` setting,
+			// so we MUST skip unless there is a match
+			match, _ := regexp.MatchString(opt.Value, title)
+			if match {
+				if p.verbose {
+					fmt.Printf("\t\t\tIncluding as this entry's title matches %s.\n", opt.Value)
+				}
+
+				// False: Do not skip/ignore this entry
+				return false
+			}
+		}
 		if opt.Name == "include" {
 
 			// We found (at least one) include option
@@ -244,7 +261,7 @@ func (p *Processor) shouldSkip(config configfile.Feed, title string, content str
 	// i.e. The entry did not include a string we regarded as mandatory.
 	if include {
 		if p.verbose {
-			fmt.Printf("\t\t\tExcluding entry, as it didn't match any include-patterns\n")
+			fmt.Printf("\t\t\tExcluding entry, as it didn't match any include, or include-title, patterns\n")
 		}
 
 		// True: skip/ignore this entry


### PR DESCRIPTION
This pull-request closes #66, by supporting a new configuration option `include-title` which matches the related option `exclude-title`.

This means it is possible to subscribe to a feed, and only receive email-notification about entries which have a title matching a particular regular expression.

I imagine the use-case for "only show matching .." is less common than "exclude matching", but the two should be symmetrical regardless.  We now allow positive/negative filtering on either body or title.