### PR TITLE
69 user agent

### DIFF
--- a/config_cmd.go
+++ b/config_cmd.go
@@ -109,12 +109,13 @@ Per-Feed Configuration Options
 
 Key           | Purpose
 --------------+--------------------------------------------------------------
+delay         | The amount of time to sleep between retried HTTP-fetches.
 exclude       | Exclude any item which matches the given regular-expression.
 exclude-title | Exclude any item with title matching the given regular-expression.
 include       | Include only items which match the given regular-expression.
 include-title | Include only items with title matching the given regular-expression.
 retry         | The maximum number of times to retry a failing HTTP-fetch.
-delay         | The amount of time to sleep between retried HTTP-fetches.
+user-agent    | Configure a specific User-Agent when making HTTP requests.
 
 
 Regular Expression Tips


### PR DESCRIPTION
This pull-request updates our configuration-file, such that the user can setup a per-site HTTP User-Agent.

By default all feeds are fetched via HTTP, using the user-agent "`rss2email (https://github.com/skx/rss2email)`", but this can be overridden now if needed.

Test-cases have been updated to make actual HTTP-fetches, for more coverage, but nothing significant changed otherwise.

This closes #69.