### PR TITLE
Add per-feed template option

### DIFF
--- a/config_cmd.go
+++ b/config_cmd.go
@@ -115,6 +115,7 @@ exclude-title | Exclude any item with title matching the given regular-expressio
 include       | Include only items which match the given regular-expression.
 include-title | Include only items with title matching the given regular-expression.
 retry         | The maximum number of times to retry a failing HTTP-fetch.
+template      | Feed specific email template file.
 user-agent    | Configure a specific User-Agent when making HTTP requests.
 
 

--- a/processor/emailer/emailer.go
+++ b/processor/emailer/emailer.go
@@ -27,6 +27,7 @@ import (
 	"text/template"
 
 	"github.com/mmcdole/gofeed"
+	"github.com/skx/rss2email/configfile"
 	emailtemplate "github.com/skx/rss2email/template"
 	"github.com/skx/rss2email/withstate"
 )
@@ -38,14 +39,16 @@ type Emailer struct {
 	feed *gofeed.Feed
 	// Item is the feed item itself
 	item withstate.FeedItem
+	// Config options for the feed.
+	opts []configfile.Option
 }
 
 // New creates a new Emailer object.
 //
 // The arguments are the source feed, and the feed item to which
 // we'll notify.
-func New(feed *gofeed.Feed, item withstate.FeedItem) *Emailer {
-	return &Emailer{feed: feed, item: item}
+func New(feed *gofeed.Feed, item withstate.FeedItem, opts []configfile.Option) *Emailer {
+	return &Emailer{feed: feed, item: item, opts: opts}
 }
 
 // loadTemplate loads the template used for sending the email notification.
@@ -70,6 +73,13 @@ func (e *Emailer) loadTemplate() (*template.Template, error) {
 
 	// The path to the overridden template
 	override := filepath.Join(home, ".rss2email", "email.tmpl")
+
+	// If a per feed template was set, get it here.
+	for _, opt := range e.opts {
+		if opt.Name == "template" {
+			override = filepath.Join(home, ".rss2email", opt.Value)
+		}
+	}
 
 	// If the file exists, use it.
 	_, err := os.Stat(override)

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -144,7 +144,7 @@ func (p *Processor) processFeed(entry configfile.Feed, recipients []string) erro
 					text := html2text.HTML2Text(content)
 
 					// Send the mail
-					helper := emailer.New(feed, item)
+					helper := emailer.New(feed, item, entry.Options)
 					err = helper.Sendmail(recipients, text, content)
 					if err != nil {
 						return err


### PR DESCRIPTION
Just to give context, I wanted to able to change the subject on a per feed basis to allow me to filter them in my email into categories.  The html templates seem like the cleanest way to do that.  Setting the template per feed looks like the simplest way to do it although I'm open to other ways if you prefer.