### PR TITLE
Add per-feed notify option

### DIFF
--- a/config_cmd.go
+++ b/config_cmd.go
@@ -114,6 +114,8 @@ exclude       | Exclude any item which matches the given regular-expression.
 exclude-title | Exclude any item with title matching the given regular-expression.
 include       | Include only items which match the given regular-expression.
 include-title | Include only items with title matching the given regular-expression.
+notify        | Comma-delimited list of emails to send notifications to (replaces
+              | the emails set in cron).
 retry         | The maximum number of times to retry a failing HTTP-fetch.
 template      | The path to a feed-specific email template to use.
 user-agent    | Configure a specific User-Agent when making HTTP requests.

--- a/config_cmd.go
+++ b/config_cmd.go
@@ -114,8 +114,8 @@ exclude       | Exclude any item which matches the given regular-expression.
 exclude-title | Exclude any item with title matching the given regular-expression.
 include       | Include only items which match the given regular-expression.
 include-title | Include only items with title matching the given regular-expression.
-notify        | Comma-delimited list of emails to send notifications to (replaces
-              | the emails set in cron).
+notify        | Comma-delimited list of emails to send notifications to (if set,
+              | replaces the emails set in the cron/daemon command).
 retry         | The maximum number of times to retry a failing HTTP-fetch.
 template      | The path to a feed-specific email template to use.
 user-agent    | Configure a specific User-Agent when making HTTP requests.

--- a/cron_cmd.go
+++ b/cron_cmd.go
@@ -78,7 +78,8 @@ func (c *cronCmd) Execute(args []string) int {
 		return 1
 	}
 
-	// The list of addresses to which we should send our notices.
+	// The list of addresses to which we should send our notices if the
+	// feed doesn't have the notify option set.
 	recipients := []string{}
 
 	// Save each argument away, checking it is fully-qualified.

--- a/cron_cmd.go
+++ b/cron_cmd.go
@@ -78,8 +78,8 @@ func (c *cronCmd) Execute(args []string) int {
 		return 1
 	}
 
-	// The list of addresses to which we should send our notices if the
-	// feed doesn't have the notify option set.
+	// The list of addresses to which we should send our notices unless overriden
+	// by a per-feed configuration.
 	recipients := []string{}
 
 	// Save each argument away, checking it is fully-qualified.

--- a/daemon_cmd.go
+++ b/daemon_cmd.go
@@ -62,7 +62,8 @@ func (d *daemonCmd) Execute(args []string) int {
 		return 1
 	}
 
-	// The list of addresses to which we should send our notices.
+	// The list of addresses to which we should send our notices unless overriden
+	// by a per-feed configuration.
 	recipients := []string{}
 
 	// Save each argument away, checking it is fully-qualified.

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -11,6 +11,7 @@ package processor
 import (
 	"fmt"
 	"regexp"
+	"strings"
 
 	"github.com/k3a/html2text"
 	"github.com/skx/rss2email/configfile"
@@ -60,8 +61,20 @@ func (p *Processor) ProcessFeeds(recipients []string) []error {
 	// For each feed-item contained in the feed
 	for _, entry := range entries {
 
+		// Check whether repo-specific recipients have been set.
+		// Otherwise use the default recipients set in the cron command.
+		feedRecipients := recipients
+		for _, opt := range entry.Options {
+			if opt.Name == "notify" {
+				feedRecipients = strings.Split(opt.Value, ",")
+				for i := range feedRecipients {
+					feedRecipients[i] = strings.TrimSpace(feedRecipients[i])
+				}
+			}
+		}
+
 		// Process this specific entry.
-		err := p.processFeed(entry, recipients)
+		err := p.processFeed(entry, feedRecipients)
 		if err != nil {
 			errors = append(errors, fmt.Errorf("error processing %s - %s", entry.URL, err))
 		}


### PR DESCRIPTION
This allows folks to set custom per-feed recipients via the "notify"
option, which if set will be used instead of the recipients set in the
cron or daemon command arguments.

Fixed: #73