### PR TITLE
Allow sleeping between feed-fetches.

### DIFF
--- a/add_cmd_test.go
+++ b/add_cmd_test.go
@@ -24,10 +24,10 @@ https://example.net/
 		t.Fatalf("Error creating temporary file")
 	}
 
-	if _, err := tmpfile.Write(data); err != nil {
+	if _, err = tmpfile.Write(data); err != nil {
 		t.Fatalf("Error writing to config file")
 	}
-	if err := tmpfile.Close(); err != nil {
+	if err = tmpfile.Close(); err != nil {
 		t.Fatalf("Error creating temporary file")
 	}
 

--- a/config_cmd.go
+++ b/config_cmd.go
@@ -117,7 +117,7 @@ include-title | Include only items with title matching the given regular-express
 notify        | Comma-delimited list of emails to send notifications to (if set,
               | replaces the emails set in the cron/daemon command).
 retry         | The maximum number of times to retry a failing HTTP-fetch.
-sleep         | Sleep the specified number of seconds, after making the request.
+sleep         | Sleep the specified number of seconds, before making the request.
 template      | The path to a feed-specific email template to use.
 user-agent    | Configure a specific User-Agent when making HTTP requests.
 

--- a/config_cmd.go
+++ b/config_cmd.go
@@ -117,6 +117,7 @@ include-title | Include only items with title matching the given regular-express
 notify        | Comma-delimited list of emails to send notifications to (if set,
               | replaces the emails set in the cron/daemon command).
 retry         | The maximum number of times to retry a failing HTTP-fetch.
+sleep         | Sleep the specified number of seconds, after making the request.
 template      | The path to a feed-specific email template to use.
 user-agent    | Configure a specific User-Agent when making HTTP requests.
 

--- a/del_cmd_test.go
+++ b/del_cmd_test.go
@@ -23,10 +23,10 @@ https://example.net/
 		t.Fatalf("Error creating temporary file")
 	}
 
-	if _, err := tmpfile.Write(data); err != nil {
+	if _, err = tmpfile.Write(data); err != nil {
 		t.Fatalf("Error writing to config file")
 	}
-	if err := tmpfile.Close(); err != nil {
+	if err = tmpfile.Close(); err != nil {
 		t.Fatalf("Error creating temporary file")
 	}
 

--- a/import_cmd.go
+++ b/import_cmd.go
@@ -82,7 +82,8 @@ func (i *importCmd) Execute(args []string) int {
 	for _, file := range args {
 
 		// Read content
-		data, err := ioutil.ReadFile(file)
+		var data []byte
+		data, err = ioutil.ReadFile(file)
 		if err != nil {
 			fmt.Printf("failed to read %s: %s\n", file, err.Error())
 			continue

--- a/import_cmd_test.go
+++ b/import_cmd_test.go
@@ -22,10 +22,10 @@ https://example.net/
 		t.Fatalf("Error creating temporary file")
 	}
 
-	if _, err := tmpfile.Write(data); err != nil {
+	if _, err = tmpfile.Write(data); err != nil {
 		t.Fatalf("Error writing to config file")
 	}
-	if err := tmpfile.Close(); err != nil {
+	if err = tmpfile.Close(); err != nil {
 		t.Fatalf("Error creating temporary file")
 	}
 

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -126,7 +126,7 @@ func (p *Processor) ProcessFeeds(recipients []string) []error {
 		}
 
 		// Process this specific entry.
-		err := p.processFeed(entry, feedRecipients)
+		err = p.processFeed(entry, feedRecipients)
 		if err != nil {
 			errors = append(errors, fmt.Errorf("error processing %s - %s", entry.URL, err))
 		}


### PR DESCRIPTION
Added support for a per-feed `sleep` setting, which can force a sleep before making a feed-request.

We've also tried to be smart, so that we delay 5seconds if we're fetching two consecutive feeds from the same hostname.

This was inspired by #83.