### PR TITLE
Added `unsee` command.

### DIFF
--- a/daemon_cmd.go
+++ b/daemon_cmd.go
@@ -86,9 +86,6 @@ func (d *daemonCmd) Execute(args []string) int {
 			return 1
 		}
 
-		// Close the database handle, once processed.
-		defer p.Close()
-
 		// Setup the state - note we ALWAYS send emails in this mode.
 		p.SetVerbose(d.verbose)
 		p.SetSendEmail(true)
@@ -102,6 +99,9 @@ func (d *daemonCmd) Execute(args []string) int {
 				fmt.Fprintln(os.Stderr, err.Error())
 			}
 		}
+
+		// Close the database handle, once processed.
+		p.Close()
 
 		// Default time to sleep - in minutes
 		n := 15

--- a/main.go
+++ b/main.go
@@ -43,6 +43,7 @@ func main() {
 	subcommands.Register(&listCmd{})
 	subcommands.Register(&listDefaultTemplateCmd{})
 	subcommands.Register(&seenCmd{})
+	subcommands.Register(&unseeCmd{})
 	subcommands.Register(&versionCmd{})
 
 	//

--- a/unsee_cmd.go
+++ b/unsee_cmd.go
@@ -65,12 +65,12 @@ func (u *unseeCmd) Execute(args []string) int {
 	defer db.Close()
 
 	// Keep track of buckets here
-	var bucketNames [][]byte
+	var bucketNames []string
 
 	// Record each bucket
 	db.View(func(tx *bbolt.Tx) error {
 		tx.ForEach(func(bucketName []byte, _ *bbolt.Bucket) error {
-			bucketNames = append(bucketNames, bucketName)
+			bucketNames = append(bucketNames, string(bucketName))
 			return nil
 		})
 		return nil
@@ -114,12 +114,14 @@ func (u *unseeCmd) Execute(args []string) int {
 						}
 					}
 				}
-
 			}
 
 			// Now remove
 			for _, key := range remove {
-				b.Delete([]byte(key))
+				err := b.Delete([]byte(key))
+				if err != nil {
+					fmt.Printf("Failed to remove %s - %s\n", key, err)
+				}
 			}
 			return nil
 		})


### PR DESCRIPTION
Added `unsee` subcommand.
    
Since moving to a new host it is harder to test when removing the state-file isn't a `rm` away.  Allow expiring items from the history via the `rss2email unsee https:///` link.
    
This triggers an email next time round, which confirms all is OK.

Could be updated to support regular-expressions too, I guess.