### PR TITLE
Add the Content-Base hedaer to the default template

### DIFF
--- a/template/template.txt
+++ b/template/template.txt
@@ -29,6 +29,7 @@ Subject: [rss2email] {{.Subject}}
 X-RSS-Link: {{.Link}}
 X-RSS-Feed: {{.Feed}}
 X-RSS-GUID: {{.RSSItem.GUID}}
+Content-Base: {{.Link}}
 Mime-Version: 1.0
 
 --21ee3da964c7bf70def62adb9ee1a061747003c026e363e47231258c48f1

--- a/template/template.txt
+++ b/template/template.txt
@@ -42,18 +42,13 @@ Content-Type: multipart/alternative; boundary=4186c39e13b2140c88094b3933206336f2
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: quoted-printable
 
-{{quoteprintable .Link}}
-
 {{.Text}}
 
-{{quoteprintable .Link}}
 --4186c39e13b2140c88094b3933206336f2bb3948db7ecf064c7a7d7473f2
 Content-Type: text/html; charset=UTF-8
 Content-Transfer-Encoding: quoted-printable
 
-<p><a href=3D"{{quoteprintable .Link}}">{{quoteprintable .Subject}}</a></p>
 {{.HTML}}
-<p><a href=3D"{{quoteprintable .Link}}">{{quoteprintable .Subject}}</a></p>
 --4186c39e13b2140c88094b3933206336f2bb3948db7ecf064c7a7d7473f2--
 
 --76a1282373c08a65dd49db1dea2c55111fda9a715c89720a844fabb7d497--

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -4,7 +4,7 @@ import "testing"
 
 func TestTemplate(t *testing.T) {
 	content := EmailTemplate()
-	if len(content) != 2241 {
-		t.Fatalf("unexpected template size 2241 != %d", len(content))
+	if len(content) != 2265 {
+		t.Fatalf("unexpected template size 2265 != %d", len(content))
 	}
 }

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -4,7 +4,7 @@ import "testing"
 
 func TestTemplate(t *testing.T) {
 	content := EmailTemplate()
-	if len(content) != 2265 {
-		t.Fatalf("unexpected template size 2265 != %d", len(content))
+	if len(content) != 2062 {
+		t.Fatalf("unexpected template size 2062 != %d", len(content))
 	}
 }


### PR DESCRIPTION
I figure out that this header is often used to highlight a direct link to the feed item by some MUA. Thunderbird is one of those.

A screenshot without the `Content-Base` header set:
![image](https://user-images.githubusercontent.com/37073343/166423683-f1a83508-556b-436f-8109-ba2b537b17ec.png)

A screenshot with the `Content-Base` header set:
![image](https://user-images.githubusercontent.com/37073343/166423654-06dc1ac4-2b34-4e7a-b99e-5b94409a068d.png)

**N.B.** Since I'm not a HTML expert, I'd like to hear some feedback about this change. Could this badly impact some emails? From [its definition](https://www.oreilly.com/library/view/http-the-definitive/1565925092/re12.html):

> The Content-Base header provides a way for a server to specify a base URL for resolving URLs found in the entity body of a response.[[5](https://www.oreilly.com/library/view/http-the-definitive/1565925092/re12.html#ftn.appc-FTNOTE-5)] The value of the Content-Base header is an absolute URL that can be used to resolve relative URLs found inside the entity.

I see this header might change how relative paths are resolved within the email's body.