### PR TITLE
Allow environmental variable lookup in our templates.

### DIFF
--- a/processor/emailer/emailer.go
+++ b/processor/emailer/emailer.go
@@ -23,6 +23,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"text/template"
 
 	"github.com/mmcdole/gofeed"
@@ -49,6 +50,16 @@ type Emailer struct {
 // and any associated configuration values from the source feed.
 func New(feed *gofeed.Feed, item withstate.FeedItem, opts []configfile.Option) *Emailer {
 	return &Emailer{feed: feed, item: item, opts: opts}
+}
+
+// env returns the contents of an environmental variable.
+func env(s string) string {
+        return (os.Getenv(s))
+}
+
+// split converts a string to an array.
+func split(in string, delim string) []string {
+        return strings.Split(in, delim)
 }
 
 // loadTemplate loads the template used for sending the email notification.
@@ -83,7 +94,9 @@ func (e *Emailer) loadTemplate() (*template.Template, error) {
 	// Function map allows exporting functions to the template
 	//
 	funcMap := template.FuncMap{
+                "env":     env,
 		"quoteprintable": e.toQuotedPrintable,
+		"split":     split,
 	}
 
 	tmpl := template.Must(template.New("email.tmpl").Funcs(funcMap).Parse(string(content)))

--- a/template/template.txt
+++ b/template/template.txt
@@ -15,9 +15,11 @@
      case you need access to other fields which are not exported expliclty.
      Using that approach you can access {{.RSSItem.GUID}}, for example.
 
-     Functions:
+     The following functions are also available:
 
-      {{quoteprintable .Link}}   -> Quote the specified field.
+      {{env "USER"}}              -> Return the given environmental variable
+      {{quoteprintable .Link}}    -> Quote the specified field.
+      {{split "STRING:HERE" ":"}} -> Split a string into an array by deliminator
 
      This comment will be stripped from the generated email.
 

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -3,8 +3,15 @@ package template
 import "testing"
 
 func TestTemplate(t *testing.T) {
+
+	// content of our template
 	content := EmailTemplate()
-	if len(content) != 2265 {
-		t.Fatalf("unexpected template size 2265 != %d", len(content))
+
+	// expected template length
+	length := 2457
+
+	// check the content is as big as it should be.
+	if len(content) != length {
+		t.Fatalf("unexpected template size %d != %d", length, len(content))
 	}
 }


### PR DESCRIPTION
This pull-request closes #97, by allowing environmental variables
to be used in the email template:

        To: {{env "RECIPIENT"}}
        From: {{env "SENDER"}}
        ...