### PR TITLE
Add X-RSS-Instance header

### DIFF
--- a/template/template.txt
+++ b/template/template.txt
@@ -30,6 +30,9 @@ To: {{.To}}
 Subject: [rss2email] {{if .Tag}}{{.Tag}} {{end}}{{.Subject}}
 X-RSS-Link: {{.Link}}
 X-RSS-Feed: {{.Feed}}
+{{- if env "RSS2EMAIL_INSTANCE_NAME"}}
+X-RSS-Instance: {{env "RSS2EMAIL_INSTANCE_NAME"}}
+{{- end}}
 {{- if .Tag}}
 X-RSS-Tags: {{.Tag}}
 {{- end}}

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -6,7 +6,7 @@ func TestTemplate(t *testing.T) {
 
 	// content and expected length
 	content := EmailTemplate()
-	length := 2529
+	length := 2628
 
 	if len(content) != length {
 		t.Fatalf("unexpected template size %d != %d", length, len(content))


### PR DESCRIPTION
The X-RSS-Instance header will be included into the email notification only if RSS2EMAIL_INSTANCE_NAME is set within the env. I found this useful to identify from which rss2email instance the email is sent from, as I do [here](https://github.com/StayPirate/sieve-susede/blob/e2eb36408ca94b980c78193bbff9ca63ccef8650/40-Feeds/40-crazybyte-security-feed.sieve#L54). Very handy to use with containers via the [.env file](https://github.com/StayPirate/rss2email/blob/375117b68f22b0da2e3f6221e4d60b3508d3d99d/.env.example#L7).

I'm sending this PR since I think other users could benefit from it.