### PR TITLE
Resolved all depreciation warnings relating to the ioutil package.

### DIFF
--- a/add_cmd_test.go
+++ b/add_cmd_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -19,7 +18,7 @@ https://example.net/
  - foo: bar
 `
 	data := []byte(content)
-	tmpfile, err := ioutil.TempFile("", "example")
+	tmpfile, err := os.CreateTemp("", "example")
 	if err != nil {
 		t.Fatalf("Error creating temporary file")
 	}

--- a/config_cmd_test.go
+++ b/config_cmd_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bytes"
 	"flag"
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -48,7 +47,7 @@ func TestMissingConfig(t *testing.T) {
 
 	// Create a temporary file, so we get a name of something
 	// that doesn't exist
-	tmpfile, err := ioutil.TempFile("", "example")
+	tmpfile, err := os.CreateTemp("", "example")
 	if err != nil {
 		t.Fatalf("failed to create temporary file")
 	}

--- a/configfile/configfile_test.go
+++ b/configfile/configfile_test.go
@@ -1,7 +1,6 @@
 package configfile
 
 import (
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -21,7 +20,7 @@ func TestDefaultPath(t *testing.T) {
 func TestExists(t *testing.T) {
 
 	// Create a temporary file
-	tmpfile, err := ioutil.TempFile("", "example")
+	tmpfile, err := os.CreateTemp("", "example")
 	if err != nil {
 		t.Fatalf("error creating temporary file")
 	}
@@ -360,7 +359,7 @@ func TestSaveBogusFile(t *testing.T) {
 func ParserHelper(t *testing.T, content string) *ConfigFile {
 
 	data := []byte(content)
-	tmpfile, err := ioutil.TempFile("", "example")
+	tmpfile, err := os.CreateTemp("", "example")
 	if err != nil {
 		t.Fatalf("Error creating temporary file")
 	}

--- a/configfile/fuzz_test.go
+++ b/configfile/fuzz_test.go
@@ -4,7 +4,6 @@
 package configfile
 
 import (
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -25,7 +24,7 @@ https://example.com
 
 	f.Fuzz(func(t *testing.T, input []byte) {
 		// Create a temporary file
-		tmpfile, _ := ioutil.TempFile("", "example")
+		tmpfile, _ := os.CreateTemp("", "example")
 
 		// Cleanup when we're done
 		defer os.Remove(tmpfile.Name())

--- a/del_cmd_test.go
+++ b/del_cmd_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -18,7 +17,7 @@ https://example.net/
  - foo: bar
 `
 	data := []byte(content)
-	tmpfile, err := ioutil.TempFile("", "example")
+	tmpfile, err := os.CreateTemp("", "example")
 	if err != nil {
 		t.Fatalf("Error creating temporary file")
 	}

--- a/export_cmd_test.go
+++ b/export_cmd_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -24,7 +23,7 @@ https://example.net/
  - foo: bar
 `
 	data := []byte(content)
-	tmpfile, err := ioutil.TempFile("", "example")
+	tmpfile, err := os.CreateTemp("", "example")
 	if err != nil {
 		t.Fatalf("Error creating temporary file")
 	}

--- a/httpfetch/httpfetch.go
+++ b/httpfetch/httpfetch.go
@@ -5,8 +5,8 @@
 package httpfetch
 
 import (
+	"io"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"strconv"
 	"time"
@@ -135,7 +135,7 @@ func (h *HTTPFetch) fetch() error {
 	defer resp.Body.Close()
 
 	// save the result
-	data, err2 := ioutil.ReadAll(resp.Body)
+	data, err2 := io.ReadAll(resp.Body)
 	h.content = string(data)
 	return err2
 }

--- a/import_cmd.go
+++ b/import_cmd.go
@@ -8,7 +8,7 @@ import (
 	"encoding/xml"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/skx/rss2email/configfile"
 	"github.com/skx/subcommands"
@@ -80,7 +80,7 @@ func (i *importCmd) Execute(args []string) int {
 
 		// Read content
 		var data []byte
-		data, err = ioutil.ReadFile(file)
+		data, err = os.ReadFile(file)
 		if err != nil {
 			fmt.Printf("failed to read %s: %s\n", file, err.Error())
 			continue

--- a/import_cmd_test.go
+++ b/import_cmd_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -17,7 +16,7 @@ https://example.net/
  - foo: bar
 `
 	data := []byte(content)
-	tmpfile, err := ioutil.TempFile("", "example")
+	tmpfile, err := os.CreateTemp("", "example")
 	if err != nil {
 		t.Fatalf("Error creating temporary file")
 	}
@@ -30,7 +29,7 @@ https://example.net/
 	}
 
 	// Create an OPML file to use as input
-	opml, err := ioutil.TempFile("", "opml")
+	opml, err := os.CreateTemp("", "opml")
 	if err != nil {
 		t.Fatalf("Error creating temporary file for OMPL input")
 	}
@@ -51,7 +50,7 @@ https://example.net/
 </body>
 </opml>
 `)
-	err = ioutil.WriteFile(opml.Name(), d1, 0644)
+	err = os.WriteFile(opml.Name(), d1, 0644)
 	if err != nil {
 		t.Fatalf("failed to write OPML file")
 	}

--- a/list_cmd_test.go
+++ b/list_cmd_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bytes"
 	"flag"
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -27,7 +26,7 @@ https://example.net/index.rss
  - foo: bar
 `
 	data := []byte(content)
-	tmpfile, err := ioutil.TempFile("", "example")
+	tmpfile, err := os.CreateTemp("", "example")
 	if err != nil {
 		t.Fatalf("Error creating temporary file")
 	}

--- a/processor/emailer/emailer.go
+++ b/processor/emailer/emailer.go
@@ -16,7 +16,7 @@ import (
 	"errors"
 	"fmt"
 	"html"
-	"io/ioutil"
+	"io"
 	"mime/quotedprintable"
 	"net/smtp"
 	"os"
@@ -90,7 +90,7 @@ func (e *Emailer) loadTemplate() (*template.Template, error) {
 	// If the file exists, use it.
 	_, err := os.Stat(override)
 	if !os.IsNotExist(err) {
-		content, err = ioutil.ReadFile(override)
+		content, err = os.ReadFile(override)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read %s: %s", override, err.Error())
 		}
@@ -324,7 +324,7 @@ func (e *Emailer) sendSendmail(addr string, content []byte) error {
 	//
 	// Read the output of Sendmail.
 	//
-	_, err = ioutil.ReadAll(stdout)
+	_, err = io.ReadAll(stdout)
 	if err != nil {
 		fmt.Printf("Error reading mail output: %s\n", err.Error())
 		return nil

--- a/usage_test.go
+++ b/usage_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"flag"
 	"github.com/skx/rss2email/configfile"
-	"io/ioutil"
 	"os"
 	"testing"
 )
@@ -67,7 +66,7 @@ func TestBrokenConfig(t *testing.T) {
 
 	data := []byte(`# This is bogus, options must follow URLs
  - foo:bar`)
-	tmpfile, err := ioutil.TempFile("", "example")
+	tmpfile, err := os.CreateTemp("", "example")
 	if err != nil {
 		t.Fatalf("Error creating temporary file")
 	}


### PR DESCRIPTION
This pull-request updates all our code to remove references to the
methods in the depreciated io/ioutil package, updating them to
use similar methods in either io. or os. packages instead.