### PR TITLE
add ability to encode header entries

### DIFF
--- a/processor/emailer/emailer.go
+++ b/processor/emailer/emailer.go
@@ -103,6 +103,7 @@ func (e *Emailer) loadTemplate() (*template.Template, error) {
 		"env":            env,
 		"quoteprintable": toQuotedPrintable,
 		"split":          split,
+		"encodeHeader":   encodeHeader,
 	}
 
 	tmpl := template.Must(template.New("email.tmpl").Funcs(funcMap).Parse(string(content)))
@@ -127,6 +128,18 @@ func toQuotedPrintable(s string) (string, error) {
 		return "", err
 	}
 	return ac.String(), nil
+}
+
+// Encode email header entries to comply with the 7bit ASCII restriction
+// of RFC 5322 according to RFC 2047.
+//
+// We use quotedprintable encoding only if necessary.
+func encodeHeader(s string) string {
+	se, err := toQuotedPrintable(s)
+	if (err != nil) || (len(se) == len(s)) {
+		return s
+	}
+	return "=?utf-8?Q?" + strings.Replace(strings.Replace(se, "?", "=3F", -1), " ", "=20", -1) + "?="
 }
 
 // Sendmail is a simple function that emails the given address.

--- a/processor/emailer/emailer.go
+++ b/processor/emailer/emailer.go
@@ -101,7 +101,7 @@ func (e *Emailer) loadTemplate() (*template.Template, error) {
 	//
 	funcMap := template.FuncMap{
 		"env":            env,
-		"quoteprintable": e.toQuotedPrintable,
+		"quoteprintable": toQuotedPrintable,
 		"split":          split,
 	}
 
@@ -115,7 +115,7 @@ func (e *Emailer) loadTemplate() (*template.Template, error) {
 // body.
 //
 // NOTE: We use this function both directly, and from within our template.
-func (e *Emailer) toQuotedPrintable(s string) (string, error) {
+func toQuotedPrintable(s string) (string, error) {
 	var ac bytes.Buffer
 	w := quotedprintable.NewWriter(&ac)
 	_, err := w.Write([]byte(s))
@@ -186,11 +186,11 @@ func (e *Emailer) Sendmail(addresses []string, textstr string, htmlstr string) e
 
 		// The real meat of the mail is the text & HTML
 		// parts.  They need to be encoded, unconditionally.
-		x.Text, err = e.toQuotedPrintable(textstr)
+		x.Text, err = toQuotedPrintable(textstr)
 		if err != nil {
 			return err
 		}
-		x.HTML, err = e.toQuotedPrintable(html.UnescapeString(htmlstr))
+		x.HTML, err = toQuotedPrintable(html.UnescapeString(htmlstr))
 		if err != nil {
 			return err
 		}

--- a/template/template.txt
+++ b/template/template.txt
@@ -19,6 +19,7 @@
 
       {{env "USER"}}              -> Return the given environmental variable
       {{quoteprintable .Link}}    -> Quote the specified field.
+      {{encodeHeader .Subject}}   -> Quote the specified field to be used in mail header.
       {{split "STRING:HERE" ":"}} -> Split a string into an array by deliminator
 
      This comment will be stripped from the generated email.
@@ -27,7 +28,7 @@
 Content-Type: multipart/mixed; boundary=21ee3da964c7bf70def62adb9ee1a061747003c026e363e47231258c48f1
 From: {{.From}}
 To: {{.To}}
-Subject: [rss2email] {{if .Tag}}{{.Tag}} {{end}}{{.Subject}}
+Subject: [rss2email] {{if .Tag}}{{encodeHeader .Tag}} {{end}}{{encodeHeader .Subject}}
 X-RSS-Link: {{.Link}}
 X-RSS-Feed: {{.Feed}}
 {{- if .Tag}}

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -6,7 +6,7 @@ func TestTemplate(t *testing.T) {
 
 	// content and expected length
 	content := EmailTemplate()
-	length := 2529
+	length := 2645
 
 	if len(content) != length {
 		t.Fatalf("unexpected template size %d != %d", length, len(content))


### PR DESCRIPTION
Encode subject, if a feed contains non-ASCII characters.
