### PR TITLE
Exclude old posts

### DIFF
--- a/config_cmd.go
+++ b/config_cmd.go
@@ -56,7 +56,6 @@ the following location:
 
      ` + path
 
-
 	doc += `
 
 Configuration File Format
@@ -101,6 +100,8 @@ Key           | Purpose
 delay         | The amount of time to sleep between retried HTTP-fetches.
 exclude       | Exclude any item which matches the given regular-expression.
 exclude-title | Exclude any item with title matching the given regular-expression.
+exclude-older | Exclude any items whose publication date is older than the 
+              | specified number of days.
 include       | Include only items which match the given regular-expression.
 include-title | Include only items with title matching the given regular-expression.
 notify        | Comma-delimited list of emails to send notifications to (if set,

--- a/config_cmd_test.go
+++ b/config_cmd_test.go
@@ -77,6 +77,7 @@ func TestMissingConfig(t *testing.T) {
 		"include-title",
 		"exclude ",
 		"exclude-title",
+		"exclude-older",
 	}
 
 	for _, txt := range expected {

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -320,8 +320,14 @@ func (p *Processor) processFeed(entry configfile.Feed, recipients []string) erro
 				// Skipping here means that we don't send an email,
 				// however we do mark it as read - so it will only
 				// be processed once.
-				if !p.shouldSkip(entry, item.Title, content) {
 
+				// check for regular expressions
+				skip := p.shouldSkip(entry, item.Title, content)
+
+				// chek for age (exclude-older)
+				skip = skip || p.shouldSkipOlder(entry, item.Published)
+
+				if !skip {
 					// Convert the content to text.
 					text := html2text.HTML2Text(content)
 
@@ -646,6 +652,39 @@ func (p *Processor) shouldSkip(config configfile.Feed, title string, content str
 
 		// True: skip/ignore this entry
 		return true
+	}
+
+	// False: Do not skip/ignore this entry
+	return false
+}
+
+// shouldSkipOlder returns true if this entry should be skipped due to age.
+//
+// Age is configured with "exclude-older" in days.
+func (p *Processor) shouldSkipOlder(config configfile.Feed, published string) bool {
+
+	// Walk over the options to see if there are any exclude-age options
+	// specified.
+	for _, opt := range config.Options {
+
+		if opt.Name == "exclude-older" {
+			pub_time, err := time.Parse(time.RFC1123, published)
+			if err != nil {
+				p.message(fmt.Sprintf("exclude-older: skipped due to failed parse of item.published as date %s", err))
+				return true
+			}
+			f, err := strconv.ParseFloat(opt.Value, 32)
+			if err != nil {
+				p.message(fmt.Sprintf("exclude-older: failed to parse config option exclude-older as float %s", err))
+				return false
+			} else {
+				delta := time.Second * time.Duration(f*24*60*60)
+				if pub_time.Add(delta).Before(time.Now()) {
+					p.message(fmt.Sprintf("\t\t\tSkipping due to 'exclude-older' (age %.1f days)", time.Since(pub_time).Hours()/24))
+					return true
+				}
+			}
+		}
 	}
 
 	// False: Do not skip/ignore this entry

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -324,7 +324,7 @@ func (p *Processor) processFeed(entry configfile.Feed, recipients []string) erro
 				// check for regular expressions
 				skip := p.shouldSkip(entry, item.Title, content)
 
-				// chek for age (exclude-older)
+				// check for age (exclude-older)
 				skip = skip || p.shouldSkipOlder(entry, item.Published)
 
 				if !skip {


### PR DESCRIPTION
On a website that I monitor with rss2email, posts are "cleaned up" from time to time. 
This leads to old posts being added back into the feed.

Since these posts were previously missing from the feed (and deleted accordingly), annoying new notifications are sent.

Here I add the possibility to filter older posts with an exclude-older:AGE(days) config option.


