### PR TITLE
Bump go version to 1.17

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ go install .
 
 **Version NOTES**:
 
-* You'll need go version **1.16** or higher to build.
+* You'll need go version **1.17** or higher to build.
   * Because we use `go embed` to embed our (default) email-template within the binary.
 * If you wish to run the included fuzz-tests against our configuration file parser you'll need at least version **1.18**.
   * See [configfile/FUZZING.md](configfile/FUZZING.md) for details.

--- a/go.mod
+++ b/go.mod
@@ -1,13 +1,22 @@
 module github.com/skx/rss2email
 
-go 1.16
+go 1.17
 
 require (
 	github.com/PuerkitoBio/goquery v1.8.1
-	github.com/andybalholm/cascadia v1.3.2 // indirect
 	github.com/k3a/html2text v1.2.1
 	github.com/mmcdole/gofeed v1.2.1
 	github.com/skx/subcommands v0.9.2
 	go.etcd.io/bbolt v1.3.7
+)
+
+require (
+	github.com/andybalholm/cascadia v1.3.2 // indirect
+	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/mmcdole/goxpp v1.1.0 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.2 // indirect
 	golang.org/x/net v0.14.0 // indirect
+	golang.org/x/sys v0.11.0 // indirect
+	golang.org/x/text v0.12.0 // indirect
 )


### PR DESCRIPTION
I tried compiling this package with go 1.16 and compilation failed. I have little experience with Go, but it looks like one of your dependencies requires go 1.17.

<details><summary>compilation logs</summary>

```
$ go build .
# golang.org/x/sys/unix
../go/pkg/mod/golang.org/x/sys@v0.11.0/unix/mremap.go:42:10: undefined: unsafe.Slice
../go/pkg/mod/golang.org/x/sys@v0.11.0/unix/syscall.go:83:16: undefined: unsafe.Slice
../go/pkg/mod/golang.org/x/sys@v0.11.0/unix/syscall_linux.go:1018:20: undefined: unsafe.Slice
../go/pkg/mod/golang.org/x/sys@v0.11.0/unix/syscall_linux.go:2300:9: undefined: unsafe.Slice
../go/pkg/mod/golang.org/x/sys@v0.11.0/unix/syscall_unix.go:118:7: undefined: unsafe.Slice
../go/pkg/mod/golang.org/x/sys@v0.11.0/unix/sysvshm_unix.go:33:7: undefined: unsafe.Slice
note: module requires Go 1.17
```

</details>

I tried compiling with go 1.17 and it worked.