### PR TITLE
Resolved all the issues found via go-linter

### DIFF
--- a/config_cmd_test.go
+++ b/config_cmd_test.go
@@ -13,7 +13,7 @@ import (
 func TestConfig(t *testing.T) {
 
 	bak := out
-	out = new(bytes.Buffer)
+	out = &bytes.Buffer{}
 	defer func() { out = bak }()
 
 	s := configCmd{}

--- a/cron_cmd.go
+++ b/cron_cmd.go
@@ -67,9 +67,7 @@ func (c *cronCmd) Arguments(f *flag.FlagSet) {
 	f.BoolVar(&c.send, "send", true, "Should we send emails, or just pretend to?")
 }
 
-//
 // Entry-point
-//
 func (c *cronCmd) Execute(args []string) int {
 
 	// No argument?  That's a bug
@@ -109,7 +107,7 @@ func (c *cronCmd) Execute(args []string) int {
 	errors := p.ProcessFeeds(recipients)
 
 	// If we found errors then show them.
-	if len(errors) > 0 {
+	if len(errors) != 0 {
 		for _, err := range errors {
 			fmt.Fprintln(os.Stderr, err.Error())
 		}

--- a/daemon_cmd.go
+++ b/daemon_cmd.go
@@ -51,9 +51,7 @@ func (d *daemonCmd) Arguments(f *flag.FlagSet) {
 	f.BoolVar(&d.verbose, "verbose", false, "Should we be extra verbose?")
 }
 
-//
 // Entry-point
-//
 func (d *daemonCmd) Execute(args []string) int {
 
 	// No argument?  That's a bug
@@ -94,7 +92,7 @@ func (d *daemonCmd) Execute(args []string) int {
 		errors := p.ProcessFeeds(recipients)
 
 		// If we found errors then show them.
-		if len(errors) > 0 {
+		if len(errors) != 0 {
 			for _, err := range errors {
 				fmt.Fprintln(os.Stderr, err.Error())
 			}

--- a/export_cmd_test.go
+++ b/export_cmd_test.go
@@ -13,7 +13,7 @@ func TestExport(t *testing.T) {
 
 	// Replace the STDIO handle
 	bak := out
-	out = new(bytes.Buffer)
+	out = &bytes.Buffer{}
 	defer func() { out = bak }()
 
 	// Create a simple configuration file

--- a/list_cmd_test.go
+++ b/list_cmd_test.go
@@ -14,7 +14,7 @@ import (
 func TestList(t *testing.T) {
 
 	bak := out
-	out = new(bytes.Buffer)
+	out = &bytes.Buffer{}
 	defer func() { out = bak }()
 
 	// Create an instance of the command, and setup a default

--- a/list_default_template_cmd_test.go
+++ b/list_default_template_cmd_test.go
@@ -10,7 +10,7 @@ import (
 func TestDefaultTemplate(t *testing.T) {
 
 	bak := out
-	out = new(bytes.Buffer)
+	out = &bytes.Buffer{}
 	defer func() { out = bak }()
 
 	s := listDefaultTemplateCmd{}

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -1,6 +1,8 @@
 package template
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestTemplate(t *testing.T) {
 

--- a/version_cmd_test.go
+++ b/version_cmd_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestVersion(t *testing.T) {
 	bak := out
-	out = new(bytes.Buffer)
+	out = &bytes.Buffer{}
 	defer func() { out = bak }()
 
 	//
@@ -37,7 +37,7 @@ func TestVersion(t *testing.T) {
 
 func TestVersionVerbose(t *testing.T) {
 	bak := out
-	out = new(bytes.Buffer)
+	out = &bytes.Buffer{}
 	defer func() { out = bak }()
 
 	//


### PR DESCRIPTION
```
$ go-linter

./cron_cmd.go:112:5: non-zero length test: use `len(s) != 0`
./daemon_cmd.go:97:6: non-zero length test: use `len(s) != 0`
./config_cmd_test.go:16:8: zero value ptr alloc: use &T{} for *T allocation
./export_cmd_test.go:16:8: zero value ptr alloc: use &T{} for *T allocation
./list_cmd_test.go:17:8: zero value ptr alloc: use &T{} for *T allocation
./list_default_template_cmd_test.go:13:8: zero value ptr alloc: use &T{} for *T allocation
./version_cmd_test.go:12:8: zero value ptr alloc: use &T{} for *T allocation
./version_cmd_test.go:40:8: zero value ptr alloc: use &T{} for *T allocation
./template/template_test.go:3:1: unit import: wrap single-package import spec into parenthesis
```

For reference
[go-linter](https://github.com/skx/dotfiles/blob/master/bin/go-linter) is a shell-script which runs a bunch of stuff, it requires some packages to be installed which is handled by
[go-tool-update](https://github.com/skx/dotfiles/blob/master/bin/go-tool-update)