### PR TITLE
Allow logging to a file

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,10 +300,14 @@ The application is configured to use a common logger, which will output all mess
   * This level is used for fatal-errors.
   * This should only be used for messages which are immediately followed by an application exit.
 
-There are two environmental variables which can be used to modify the logging output:
+There are several environmental variables which can be used to modify the logging output:
 
 * `LOG_ALL`
   * If this is set to a non-empty string all levels will be shown (DEBUG, WARN and ERROR).
+* `LOG_FILE_PATH`
+  * The name of the file to duplicate logging message to, defaults to being `rss2email.log`.
+* `LOG_FILE_DISABLE`
+  * Set this to any non-empty value to disable the logfile entirely.
 * `LOG_JSON`
   * If this is set to a non-empty string the logging messages will be output in JSON format.
   * This is useful if you're collecting (container) messages in datadog, loki, sumologic, or something similar.


### PR DESCRIPTION
In #122 we updated our codebase to ensure that we used a common logging handle to send our output messages to the user:

* This included warnings and errors by default.
* However "developer", or other internal messages, were also available.

This pull-request builds upon that work to write the log messages to a file, as well as showing them to the user.  By default a file `rss2email.log` is generated when the application starts and log entries are appended to it.

However:

* LOG_FILE_PATH can be set to a different path.
* LOG_FILE_DISABLE can be used to disable this duplication.

Why do this?  Partly for reference, but also partly to allow a local setup to view errors.

We could now resolve #119 by adding a cronjob:

        #!/bin/sh
        # show logs, and delete them, run once per day
        cat .../rss2email.log
        rm .../rss2email.log

(Of course this might not work 100% as the current approach assumes the file is open forever in the case of `daemon` sub-command.)

This isn't a complete solution, but without getting into the whole template-customization and more complex considerations it's not a terrible thing to do.