### PR TITLE
Update docker-compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,11 +3,18 @@ services:
   rss2email:
     command: daemon -verbose steve@steve.fi
     entrypoint: rss2email
+    working_dir: /app
+    user: app
     environment:
+    - TZ=UTC
     - SMTP_USERNAME=steve@example.com
     - SMTP_PASSWORD=blah.blah.blah!
     - SMTP_HOST=smtp.gmail.com
-    restart: always
-    image: skx/rss2email
+    - SMTP_PORT=587
+    restart: unless-stopped
+    image: ghcr.io/skx/rss2email:master
     volumes:
-    - /srv/rss2email/config/:/app/.rss2email/
+    - rss2email-data:/app/.rss2email
+
+volumes:
+  rss2email-data:


### PR DESCRIPTION
- Switched upstream registry from docker-hub to GHCR.
- Made the docker-compose file more explicit
- Switched the restart policy to unless-stopped to allow users to manually stop the container
- Using a named volume make it more portable