### PR TITLE
Do not trigger daily image rebuild

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -6,8 +6,6 @@ name: Docker
 # documentation.
 
 on:
-  schedule:
-    - cron: '32 19 * * *'
   push:
     branches: [ "master" ]
     # Publish semver tags as releases.


### PR DESCRIPTION
Daily build the container image, even when there's no changes in the code, is quite inconvenient and a waste of resources. It is inconvenient for processes that daily monitor for container image updates (I do that), automatically pull and update containers every time a new image is detected.

I think it is safe to remove the schedule-trigger because the GH action is equipped with other more reasonable triggers:
 * For each commit in master branch
 * For new pushed tag in the form of v*.*.*
 * For PR against the master branch