### PR TITLE
Enable better control of logging levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,8 +310,11 @@ The application is configured to use a common logger, which will output all mess
 
 There are several environmental variables which can be used to modify the logging output:
 
-* `LOG_ALL`
-  * If this is set to a non-empty string all levels will be shown (DEBUG, WARN and ERROR).
+* `LOG_LEVEL`
+  * This may be set to one of several values:
+    * `ERROR`: Show only errors.
+    * `WARN`: Show errors, and warnings.
+    * `DEBUG`: Show errors, warnings, and internal debugging messages (very verbose).
 * `LOG_FILE_PATH`
   * The name of the file to duplicate logging message to, defaults to being `rss2email.log`.
 * `LOG_FILE_DISABLE`

--- a/main.go
+++ b/main.go
@@ -33,16 +33,37 @@ func recoverPanic() {
 func main() {
 
 	//
-	// Setup our default logging level
+	// Setup our default logging level, which will show
+	// both warnings and errors.
 	//
 	loggerLevel = &slog.LevelVar{}
 	loggerLevel.Set(slog.LevelWarn)
 
 	//
-	// Allow showing "all the logs"
+	// If the user wants a different level they can choose it.
+	//
+	level := os.Getenv("LOG_LEVEL")
+
+	//
+	// Legacy/Compatibility
 	//
 	if os.Getenv("LOG_ALL") != "" {
+		level = "DEBUG"
+	}
+
+	// Simplify things by only caring about upper-case
+	level = strings.ToUpper(level)
+
+	switch level {
+	case "DEBUG":
 		loggerLevel.Set(slog.LevelDebug)
+	case "WARN":
+		loggerLevel.Set(slog.LevelWarn)
+	case "ERROR":
+		loggerLevel.Set(slog.LevelError)
+	default:
+		fmt.Printf("Unknown logging-level '%s'\n", level)
+		return
 	}
 
 	// Those handler options


### PR DESCRIPTION
As noted in a comment on #103 it would be nice to have the ability to show only errors - not warnings and debug-messages too.

This pull-request removes "LOG_ALL" from the documentation, replacing it with "LOG_LEVEL" - for compatibility LOG_ALL becomes "LOG_LEVEL=DEBUG".  The new LOG_LEVEL allows :

* ERROR
  * Show only errors.
* WARN
  * Show errors _and_ warnings.
* DEBUG
  * Show errors, warnings, _and_ debug-messages.