### PR TITLE
Update the log-levels of some messages

### DIFF
--- a/daemon_cmd.go
+++ b/daemon_cmd.go
@@ -113,7 +113,7 @@ func (d *daemonCmd) Execute(args []string) int {
 		// Default time to sleep - in minutes
 		n := 5
 
-		logger.Warn("sleeping before polling feeds again",
+		logger.Debug("sleeping before polling feeds again",
 			slog.Int("delay.minutes", n))
 
 		time.Sleep(time.Duration(n) * time.Minute)

--- a/import_cmd.go
+++ b/import_cmd.go
@@ -85,7 +85,7 @@ func (i *importCmd) Execute(args []string) int {
 		var data []byte
 		data, err = os.ReadFile(file)
 		if err != nil {
-			logger.Warn("failed to read file", slog.String("file", file), slog.String("error", err.Error()))
+			logger.Error("failed to read file", slog.String("file", file), slog.String("error", err.Error()))
 			continue
 		}
 
@@ -93,7 +93,7 @@ func (i *importCmd) Execute(args []string) int {
 		o := opml{}
 		err = xml.Unmarshal(data, &o)
 		if err != nil {
-			logger.Warn("failed to parse XML file", slog.String("file", file), slog.String("error", err.Error()))
+			logger.Error("failed to parse XML file", slog.String("file", file), slog.String("error", err.Error()))
 			continue
 		}
 

--- a/processor/emailer/emailer.go
+++ b/processor/emailer/emailer.go
@@ -263,7 +263,7 @@ func (e *Emailer) Sendmail(addresses []string, textstr string, htmlstr string) e
 			err := e.sendSMTP(addr, buf.Bytes())
 			if err != nil {
 
-				e.logger.Warn("error sending email",
+				e.logger.Error("error sending email",
 					slog.String("recipient", addr),
 					slog.String("method", "smtp"),
 					slog.String("error", err.Error()))
@@ -283,7 +283,7 @@ func (e *Emailer) Sendmail(addresses []string, textstr string, htmlstr string) e
 
 			err := e.sendSendmail(addr, buf.Bytes())
 			if err != nil {
-				e.logger.Warn("error sending email",
+				e.logger.Error("error sending email",
 					slog.String("recipient", addr),
 					slog.String("method", "sendmail"),
 					slog.String("error", err.Error()))
@@ -369,7 +369,7 @@ func (e *Emailer) sendSendmail(addr string, content []byte) error {
 	stdin, err := sendmail.StdinPipe()
 	if err != nil {
 
-		e.logger.Warn("error creating STDIN pipe to sendmail",
+		e.logger.Error("error creating STDIN pipe to sendmail",
 			slog.String("recipient", addr),
 			slog.String("error", err.Error()))
 
@@ -382,7 +382,7 @@ func (e *Emailer) sendSendmail(addr string, content []byte) error {
 	stdout, err := sendmail.StdoutPipe()
 	if err != nil {
 
-		e.logger.Warn("error creating STDOUT pipe to sendmail",
+		e.logger.Error("error creating STDOUT pipe to sendmail",
 			slog.String("recipient", addr),
 			slog.String("error", err.Error()))
 
@@ -395,7 +395,7 @@ func (e *Emailer) sendSendmail(addr string, content []byte) error {
 	err = sendmail.Start()
 	if err != nil {
 
-		e.logger.Warn("error starting sendmail",
+		e.logger.Error("error starting sendmail",
 			slog.String("recipient", addr),
 			slog.String("error", err.Error()))
 
@@ -404,7 +404,7 @@ func (e *Emailer) sendSendmail(addr string, content []byte) error {
 	_, err = stdin.Write(content)
 	if err != nil {
 
-		e.logger.Warn("error writing to sendmail pipe",
+		e.logger.Error("error writing to sendmail pipe",
 			slog.String("recipient", addr),
 			slog.String("error", err.Error()))
 
@@ -418,7 +418,7 @@ func (e *Emailer) sendSendmail(addr string, content []byte) error {
 	_, err = io.ReadAll(stdout)
 	if err != nil {
 
-		e.logger.Warn("error reading from sendmail pipe",
+		e.logger.Error("error reading from sendmail pipe",
 			slog.String("recipient", addr),
 			slog.String("error", err.Error()))
 
@@ -431,7 +431,7 @@ func (e *Emailer) sendSendmail(addr string, content []byte) error {
 	err = sendmail.Wait()
 	if err != nil {
 
-		e.logger.Warn("error awaiting sendmail completion",
+		e.logger.Error("error awaiting sendmail completion",
 			slog.String("recipient", addr),
 			slog.String("error", err.Error()))
 

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -283,7 +283,7 @@ func (p *Processor) processFeed(entry configfile.Feed, recipients []string) erro
 			return nil
 		}
 
-		logger.Warn("failed to fetch feed",
+		logger.Error("failed to fetch feed",
 			slog.String("error", err.Error()))
 		return err
 	}
@@ -415,7 +415,7 @@ func (p *Processor) processFeed(entry configfile.Feed, recipients []string) erro
 					err = helper.Sendmail(recipients, text, content)
 					if err != nil {
 
-						logger.Warn("failed to send email",
+						logger.Error("failed to send email",
 							slog.String("recipients", strings.Join(recipients, ",")),
 							slog.String("error", err.Error()))
 
@@ -437,7 +437,7 @@ func (p *Processor) processFeed(entry configfile.Feed, recipients []string) erro
 		// due to error, and that keeps happening forever...
 		err = p.recordItem(entry.URL, item.Link)
 		if err != nil {
-			logger.Warn("failed to mark item as processed",
+			logger.Error("failed to mark item as processed",
 				slog.String("error", err.Error()))
 			return err
 		}
@@ -451,7 +451,7 @@ func (p *Processor) processFeed(entry configfile.Feed, recipients []string) erro
 	err = p.pruneFeed(entry.URL, items)
 	if err != nil {
 
-		logger.Warn("failed to prune bolddb",
+		logger.Error("failed to prune bolddb",
 			slog.String("error", err.Error()))
 
 		return fmt.Errorf("error pruning boltdb for %s: %s", entry.URL, err)
@@ -479,7 +479,7 @@ func (p *Processor) seenItem(feed string, entry string) bool {
 		return nil
 	})
 	if err != nil {
-		p.logger.Warn("error checking state of item",
+		p.logger.Error("error checking state of item",
 			slog.String("feed", feed),
 			slog.String("item", entry),
 			slog.String("error", err.Error()))
@@ -504,7 +504,7 @@ func (p *Processor) recordItem(feed string, entry string) error {
 	})
 
 	if err != nil {
-		p.logger.Warn("error recording state of item",
+		p.logger.Error("error recording state of item",
 			slog.String("feed", feed),
 			slog.String("item", entry),
 			slog.String("error", err.Error()))
@@ -562,7 +562,7 @@ func (p *Processor) pruneFeed(feed string, items []string) error {
 
 	if err != nil {
 
-		p.logger.Warn("error getting all bucket keys",
+		p.logger.Error("error getting all bucket keys",
 			slog.String("error", err.Error()))
 		return err
 	}
@@ -580,7 +580,7 @@ func (p *Processor) pruneFeed(feed string, items []string) error {
 		})
 		if err != nil {
 
-			p.logger.Warn("error deleting key from bucket",
+			p.logger.Error("error deleting key from bucket",
 				slog.String("entry", ent),
 				slog.String("error", err.Error()))
 
@@ -626,7 +626,7 @@ func (p *Processor) pruneUnknownFeeds(feeds []string) error {
 	})
 
 	if err != nil {
-		p.logger.Warn("error finding orphaned buckets",
+		p.logger.Error("error finding orphaned buckets",
 			slog.String("error", err.Error()))
 
 		return err
@@ -648,7 +648,7 @@ func (p *Processor) pruneUnknownFeeds(feeds []string) error {
 				err := b.Delete(k)
 				if err != nil {
 
-					p.logger.Warn("error removing key from bucket",
+					p.logger.Error("error removing key from bucket",
 						slog.String("bucket", bucket),
 						slog.String("key", string(k)),
 						slog.String("error", err.Error()))
@@ -660,7 +660,7 @@ func (p *Processor) pruneUnknownFeeds(feeds []string) error {
 			// Now delete the bucket itself
 			err := tx.DeleteBucket([]byte(bucket))
 			if err != nil {
-				p.logger.Warn("error removing  bucket",
+				p.logger.Error("error removing bucket",
 					slog.String("bucket", bucket),
 					slog.String("error", err.Error()))
 				return fmt.Errorf("failed to remove bucket %s: %s", bucket, err)

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -217,7 +217,7 @@ func (p *Processor) ProcessFeeds(recipients []string) []error {
 		// If we're supposed to sleep, do so
 		if sleep != 0 {
 
-			p.logger.Warn("sleeping",
+			p.logger.Debug("sleeping",
 				slog.Int("sleep", sleep))
 
 			time.Sleep(time.Duration(sleep) * time.Second)
@@ -279,7 +279,7 @@ func (p *Processor) processFeed(entry configfile.Feed, recipients []string) erro
 	if err != nil {
 
 		if err == httpfetch.ErrUnchanged {
-			logger.Warn("remote feed unchanged, skipping")
+			logger.Debug("remote feed unchanged, skipping")
 			return nil
 		}
 


### PR DESCRIPTION
This pull-request rejigs a couple of the logged messages:

* Changes a couple of Warning-level messages to be Debug-level.
  * They're not really warnings per se, and they can be hidden by default.
* Upgrades a few Warning-level messages to be Error-level.
  * Failures to send emails, etc, are errors not warnings.
  * Basically every Warn-level message which contains the text message "error" should be an error rather than a warning.

This pull-request updates #143, although it does not resolve it.