### PR TITLE
Add List-ID header in mail template

### DIFF
--- a/processor/emailer/emailer.go
+++ b/processor/emailer/emailer.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 	"text/template"
@@ -123,7 +124,7 @@ func (e *Emailer) loadTemplate() (*template.Template, error) {
 		"quoteprintable":   toQuotedPrintable,
 		"split":            split,
 		"encodeHeader":     encodeHeader,
-		"makeListIdHeader": makeListIdHeader
+		"makeListIdHeader": makeListIdHeader,
 	}
 
 	tmpl := template.Must(template.New("email.tmpl").Funcs(funcMap).Parse(string(content)))
@@ -170,20 +171,20 @@ func encodeHeader(s string) string {
 // The function has some special code to handle an URL.
 func makeListIdHeader(s string) string {
 	// Strip scheme
-	url = strings.TrimPrefix(url, "http://")
-	url = strings.TrimPrefix(url, "https://")
+	sh := strings.TrimPrefix(s, "http://")
+	sh = strings.TrimPrefix(sh, "https://")
 
 	// Only allow valid atext characters and dots; replace others with dots
 	re := regexp.MustCompile(`[^A-Za-z0-9!#$%&'*+\-=?^_` + "`" + `{|}~.]+`)
-	url = re.ReplaceAllString(url, ".")
+	sh = re.ReplaceAllString(sh, ".")
 
 	// Collapse multiple dots
-	url = regexp.MustCompile(`\.+`).ReplaceAllString(url, ".")
+	sh = regexp.MustCompile(`\.+`).ReplaceAllString(sh, ".")
 
 	// Clean url
-	url = strings.Trim(url, ".")
+	sh = strings.Trim(sh, ".")
 
-	return url + ".localhost"
+	return sh + ".localhost"
 }
 
 // Sendmail is a simple function that emails the given address.

--- a/processor/emailer/emailer.go
+++ b/processor/emailer/emailer.go
@@ -166,7 +166,7 @@ func encodeHeader(s string) string {
 }
 
 // Encode email header entry to comply List-ID restriction of RFC 2919
-// ccording to DRUMS.
+// according to DRUMS.
 //
 // The function has some special code to handle an URL.
 func makeListIdHeader(s string) string {
@@ -175,7 +175,7 @@ func makeListIdHeader(s string) string {
 	sh = strings.TrimPrefix(sh, "https://")
 
 	// Only allow valid atext characters and dots; replace others with dots
-	re := regexp.MustCompile(`[^A-Za-z0-9!#$%&'*+\-=?^_` + "`" + `{|}~.]+`)
+	re := regexp.MustCompile(`[^A-Za-z0-9!$%&'*+\-=^_` + "`" + `{|}~.]+`)
 	sh = re.ReplaceAllString(sh, ".")
 
 	// Collapse multiple dots

--- a/processor/emailer/emailer.go
+++ b/processor/emailer/emailer.go
@@ -165,7 +165,7 @@ func encodeHeader(s string) string {
 	return "=?utf-8?Q?" + se + "?="
 }
 
-// Encode email header entry to comply List-ID restriction of RFC 2919
+// makeListIdHeader encodes email header entry to comply List-ID restriction of RFC 2919
 // according to DRUMS.
 //
 // The function has some special code to handle an URL.

--- a/processor/emailer/emailer_test.go
+++ b/processor/emailer/emailer_test.go
@@ -41,13 +41,13 @@ func TestMakeListIdHeader(t *testing.T) {
 		if got != tt.expected {
 			t.Errorf("makeListIdHeader(%q) = %q; want %q", tt.input, got, tt.expected)
 		}
-        // Check that every character in got is allowed
+		// Check that every character in got is allowed
 		// from https://datatracker.ietf.org/doc/html/rfc2822#section-3.2.4
-        allowed := "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!#$%&'*+-/=?^_`{|}~."
-        for i, c := range got {
-            if !strings.ContainsRune(allowed, c) {
-                t.Errorf("makeListIdHeader(%q) produced invalid char %q at position %d", tt.input, c, i)
-            }
-        }
+		allowed := "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!#$%&'*+-/=?^_`{|}~."
+		for i, c := range got {
+			if !strings.ContainsRune(allowed, c) {
+				t.Errorf("makeListIdHeader(%q) produced invalid char %q at position %d", tt.input, c, i)
+			}
+		}
 	}
 }

--- a/processor/emailer/emailer_test.go
+++ b/processor/emailer/emailer_test.go
@@ -1,0 +1,53 @@
+package emailer
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestMakeListIdHeader(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{
+			input:    "http://example.com/feed",
+			expected: "example.com.feed.localhost",
+		},
+		{
+			input:    "https://example.com/feed",
+			expected: "example.com.feed.localhost",
+		},
+		{
+			input:    "https://example.com/foo/bar?baz=qux",
+			expected: "example.com.foo.bar.baz=qux.localhost",
+		},
+		{
+			input:    "example.com/feed",
+			expected: "example.com.feed.localhost",
+		},
+		{
+			input:    "https://example.com/foo//bar///baz",
+			expected: "example.com.foo.bar.baz.localhost",
+		},
+		{
+			input:    "https://example.com/foo@bar#baz",
+			expected: "example.com.foo.bar.baz.localhost",
+		},
+	}
+
+	for _, tt := range tests {
+		got := makeListIdHeader(tt.input)
+		if got != tt.expected {
+			t.Errorf("makeListIdHeader(%q) = %q; want %q", tt.input, got, tt.expected)
+		}
+        // Check that every character in got is allowed
+		// from https://datatracker.ietf.org/doc/html/rfc2822#section-3.2.4
+        allowed := "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!#$%&'*+-/=?^_`{|}~."
+        for i, c := range got {
+            if !strings.ContainsRune(allowed, c) {
+                t.Errorf("makeListIdHeader(%q) produced invalid char %q at position %d", tt.input, c, i)
+            }
+        }
+	}
+}

--- a/template/template.txt
+++ b/template/template.txt
@@ -21,6 +21,7 @@
       {{quoteprintable .Link}}    -> Quote the specified field.
       {{encodeHeader .Subject}}   -> Quote the specified field to be used in mail header.
       {{split "STRING:HERE" ":"}} -> Split a string into an array by deliminator
+      {{makeListHeader .Feed}}    -> Generate a valid List-ID header from variable
 
      This comment will be stripped from the generated email.
 
@@ -35,6 +36,7 @@ X-RSS-Feed: {{.Feed}}
 X-RSS-Tags: {{.Tag}}
 {{- end}}
 X-RSS-GUID: {{.RSSItem.GUID}}
+List-ID: {{makeListHeader .Feed}}
 Content-Base: {{.Link}}
 Mime-Version: 1.0
 

--- a/template/template.txt
+++ b/template/template.txt
@@ -21,7 +21,7 @@
       {{quoteprintable .Link}}    -> Quote the specified field.
       {{encodeHeader .Subject}}   -> Quote the specified field to be used in mail header.
       {{split "STRING:HERE" ":"}} -> Split a string into an array by deliminator
-      {{makeListHeader .Feed}}    -> Generate a valid List-ID header from variable
+      {{makeListIdHeader .Feed}}    -> Generate a valid List-ID header from variable
 
      This comment will be stripped from the generated email.
 
@@ -36,7 +36,7 @@ X-RSS-Feed: {{.Feed}}
 X-RSS-Tags: {{.Tag}}
 {{- end}}
 X-RSS-GUID: {{.RSSItem.GUID}}
-List-ID: {{makeListHeader .Feed}}
+List-ID: {{makeListIdHeader .Feed}}
 Content-Base: {{.Link}}
 Mime-Version: 1.0
 

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -8,7 +8,7 @@ func TestTemplate(t *testing.T) {
 
 	// content and expected length
 	content := EmailTemplate()
-	length := 2645
+	length := 2766
 
 	if len(content) != length {
 		t.Fatalf("unexpected template size %d != %d", length, len(content))


### PR DESCRIPTION
Hi,
close #146

I've added the function `makeListIdHeader`, listed in the template mapping, added to the default template and created a test.